### PR TITLE
Fixing populate_fields method to handle multiple itemtypes

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -263,9 +263,13 @@ function plugin_datainjection_populate_fields() {
    $found = $container->find("`is_active` = 1");
 
    foreach ($found as $id => $values) {
-      $classname = "PluginFields"
-                     . ucfirst($values['itemtype'] . preg_replace('/s$/', '', $values['name']))
+      $types = json_decode($values['itemtypes']);
+
+      foreach ($types as $type) {
+         $classname = "PluginFields"
+                     . ucfirst($type. preg_replace('/s$/', '', $values['name']))
                      . 'Injection';
-      $INJECTABLE_TYPES[$classname]               = 'fields';
+         $INJECTABLE_TYPES[$classname]               = 'fields';
+      }
    }
 }


### PR DESCRIPTION
The "itemtype" column in containers table doesn't exist anymore, we have to json decode the "itemtypes" column and loop on the result to add each type individually.