### PR TITLE
bug fix - field render issue depending on rights access

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -506,8 +506,7 @@ class PluginFieldsField extends CommonDBTM {
          $eq = -3;
       }
 
-      if (!$item->can($items_id, UPDATE)
-          && !$item->can($items_id, DELETE)) {
+      if (!$item->can($items_id, UPDATE)) {
          $eq++;
       }
 


### PR DESCRIPTION
Before : when the user had the delete right and no update right on an item type, there was a rendering bug on field type "Insertion in the form (before save
button)"
The condition used on the delete right is useless because the delete right doesn't change the form, while the update right add a Save button.