### PR TITLE
Editing back on fields under tickets with status closed and Solved

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -609,13 +609,11 @@ class PluginFieldsField extends CommonDBTM {
             $items_obj->getEmpty();
          }
 
-         /** Editing fields back on closed and solved tickets
-          *if (in_array($items_obj->fields['status'], $items_obj->getClosedStatusArray())
-          *     || in_array($items_obj->fields['status'], $items_obj->getSolvedStatusArray())
-          *     || $first_found_p['right'] != CREATE) {
-          *    $canedit = false;
-          *}
-          */
+       // Editing fields on closed and solved tickets
+          if ($first_found_p['right'] != CREATE) {
+              $canedit = false;
+          }
+          
       } else {
          if ($first_found_p['right'] != CREATE) {
             $canedit = false;

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -609,11 +609,13 @@ class PluginFieldsField extends CommonDBTM {
             $items_obj->getEmpty();
          }
 
-         if (in_array($items_obj->fields['status'], $items_obj->getClosedStatusArray())
-             || in_array($items_obj->fields['status'], $items_obj->getSolvedStatusArray())
-             || $first_found_p['right'] != CREATE) {
-            $canedit = false;
-         }
+         /** Editing fields back on closed and solved tickets
+          *if (in_array($items_obj->fields['status'], $items_obj->getClosedStatusArray())
+          *     || in_array($items_obj->fields['status'], $items_obj->getSolvedStatusArray())
+          *     || $first_found_p['right'] != CREATE) {
+          *    $canedit = false;
+          *}
+          */
       } else {
          if ($first_found_p['right'] != CREATE) {
             $canedit = false;


### PR DESCRIPTION
Some only charge when the ticket is in Resolved or Closed status.
Indeed sometimes we only bill once the prestation carried out and not before.
So we must be able to edit the created fields regardless of the status.