### PR TITLE
Add fields to Lines

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -719,7 +719,8 @@ class PluginFieldsContainer extends CommonDBTM {
          'Supplier'        => Supplier::getTypeName(2),
          'Contact'         => Contact::getTypeName(2),
          'Contract'        => Contract::getTypeName(2),
-         'Document'        => Document::getTypeName(2)
+         'Document'        => Document::getTypeName(2),
+         'Line'            => Line::getTypeName(2),
       ];
 
       $tabs[__('Tools')] = [


### PR DESCRIPTION
Associated Management/Line to Block #232 

The fields created do not appear in the drop-down menu to select default items to display because a function in hook.php
```
function plugin_fields_getAddSearchOptions($itemtype) {
   if (isset($_SESSION['glpiactiveentities'])
       && is_array($_SESSION['glpiactiveentities'])
       && count($_SESSION['glpiactiveentities']) > 0) {

      $itemtypes = PluginFieldsContainer::getEntries('all');
      if ($itemtypes !== false && in_array($itemtype, $itemtypes)) {
         return PluginFieldsContainer::getAddSearchOptions($itemtype);
      }
   }

   return null;
}
```
the php function in_array($itemtype, $itemtypes) return false because $itemtype is in lowercase and the $itemtypes is in upper case.
I think this is caused by an error in the GLPI