### PR TITLE
Fix warning: "continue" targeting switch is equivalent to "break"

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -795,7 +795,7 @@ class PluginFieldsField extends CommonDBTM {
                   break;
                case 'dropdownuser':
                   if ($massiveaction) {
-                     continue;
+                     break;
                   }
                   if ($canedit && !$readonly) {
                      $html.= User::dropdown(['name'      => $field['name'],


### PR DESCRIPTION
Fixes #316.

On PHP 7.3, using a continue in a switch is trigerring a warning.

I did not find how (and if) this part of code is used, so I just replace the `continue` by a `break` to keep same behaviour.