### PR TITLE
1.10 carm

### DIFF
--- a/front/field.form.php
+++ b/front/field.form.php
@@ -16,11 +16,11 @@ if (isset($_POST["add"])) {
 } else if (isset($_POST["delete"])) {
    $field->check($_POST['id'], DELETE);
    $field->delete($_POST);
-   Html::back();
+   Html::redirect($CFG_GLPI["root_doc"]."/plugins/fields/front/container.form.php?id=".$_POST["plugin_fields_containers_id"]);
 } else if (isset($_REQUEST["purge"])) {
    $field->check($_REQUEST['id'], PURGE);
    $field->delete($_REQUEST, 1);
-   Html::back();
+   Html::redirect($CFG_GLPI["root_doc"]."/plugins/fields/front/container.form.php?id=".$_POST["plugin_fields_containers_id"]);
 } else if (isset($_POST["update"])) {
    $field->check($_POST['id'], UPDATE);
    $field->update($_POST);

--- a/front/labeltranslation.form.php
+++ b/front/labeltranslation.form.php
@@ -35,5 +35,10 @@ if (isset($_POST['add'])) {
 
 } else if (isset($_POST['update'])) {
    $translation->update($_POST);
-}
+} else if (isset($_POST['purge'])) { // INICIO [CRI] : Elimina una traducción permanentemente desde el botón eliminar de la traducción
+   $translation->delete($_POST);
+} // FINAL [CRI] : Elimina una traducción permanentemente desde el botón eliminar de la traducción
+
+
+
 Html::back();

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1000,9 +1000,35 @@ class PluginFieldsContainer extends CommonDBTM {
          $data['id'] = $first_found['id'];
          $obj->update($data);
 
-         //construct history on itemtype object (Historical tab)
-         self::constructHistory($data['plugin_fields_containers_id'], $items_id,
-                                $itemtype, $data, $first_found);
+  // INICIO [CRI] : JMZ18G ACTUALIZAR DATE_MOD EN EL ACTIVO E INSERTAR CAMBIO EN EL LOG
+if (!empty($obj->oldvalues)){ 
+
+$objeto = new $itemtype();
+//$found = $objeto->find(['id' => $data["items_id"]]);
+
+$params = [
+"id" => $data["items_id"],
+"date_mod" => $_SESSION["glpi_currenttime"],
+];
+if ($objeto->update($params)){
+
+         if (isset($objeto->input['_no_message_link'])) {
+            $display = $objeto->getNameID();
+         } else {
+            $display = $objeto->getLink();
+         }
+         //TRANS : %s is the description of the updated item
+         Session::addMessageAfterRedirect(sprintf(__('%1$s: %2$s'), __('Item successfully updated'), $display));
+		 
+     if (count($obj->oldvalues)) {
+         Log::constructHistory($objeto, $obj->oldvalues, $obj->fields);
+      }		 
+		 
+}	 		 
+
+
+}
+// FINAL [CRI] : JMZ18G ACTUALIZAR DATE_MOD EN EL ACTIVO E INSERTAR CAMBIO EN EL LOG
       }
 
       return true;
@@ -1554,8 +1580,7 @@ class PluginFieldsContainer extends CommonDBTM {
                $opt[$i]['datatype'] = "number";
                break;
             case 'date':
-            case 'datetime':
-			case 'getdate':  // INICIO [CRI] : Procesar nuevos campo fecha de sistema
+            case 'datetime':			
                $opt[$i]['datatype'] = $data['type'];
                break;		   
             default:

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -93,6 +93,7 @@ class PluginFieldsField extends CommonDBTM {
       global $DB;
       //parse name
       $input['name'] = $this->prepareName($input);
+	  $input['label'] = $this->prepareLabel($input); // INICIO [CRI] : JMZ18G CONTROLA QUE EL CAMPO FIELD NO SE QUEDE VACÍO
 
       if ($input['type'] === "dropdown") {
          //search if dropdown already exist in this container
@@ -191,6 +192,23 @@ class PluginFieldsField extends CommonDBTM {
       return true;
    }
 
+// INICIO [CRI] : JMZ18G CONTROLA QUE EL CAMPO FIELD NO SE QUEDE VACÍO
+   /**
+    * @param  array $input the field form input
+    * @return string  the parsed name
+    */
+   function prepareLabel($input) {
+      $toolbox = new PluginFieldsToolbox();
+
+      //contruct field label by processing name 
+	  if (empty($input['label'])) {
+         $input['label'] = $input['name'];
+      }		  
+
+      return $input['label'];
+   }
+// FINAL [CRI] : JMZ18G CONTROLA QUE EL CAMPO FIELD NO SE QUEDE VACÍO
+
 
    /**
     * parse name for avoid non alphanumeric char in it and conflict with other fields
@@ -202,8 +220,12 @@ class PluginFieldsField extends CommonDBTM {
 
       //contruct field name by processing label (remove non alphanumeric char)
       if (empty($input['name'])) {
-         $input['name'] = $toolbox->getSystemNameFromLabel($input['label']) . 'field';
-      }
+         $input['name'] = $toolbox->getSystemNameFromLabel($input['label']) . 'field';      
+	  }
+	  
+	  if (!empty($input['name'])) {
+         $input['name'] = $toolbox->getSystemNameFromLabel($input['name']);
+      }		  
 
       //for dropdown, if already exist, link to it
       if (isset($input['type']) && $input['type'] === "dropdown") {
@@ -723,9 +745,10 @@ class PluginFieldsField extends CommonDBTM {
 			
 			// INICIO [CRI] : Filtro para desplegable			
 			// Obtener la condicion
-			$condition = array();			
+			$condition = array();		
+		
 			if (empty($value) && !empty($field['condition'])) {
-               //$condition = $field['condition'];			   
+               //$condition = $field['condition'];			 
 			   array_push($condition,$field['condition']);  // [CRI] Añadir filtros desplegable objeto
             }
 			// FIN [CRI] : Filtro para desplegable
@@ -856,7 +879,7 @@ class PluginFieldsField extends CommonDBTM {
 				  
 				  break;
 				  
-				// INICIO [CRI] : Insertar nuevos tipos de Objeto y Fecha de sistema				  
+				// INICIO [CRI] : Insertar nuevo tipo de Objeto				  
                case 'dropdownitem':
                   if ($massiveaction) {
                      continue;
@@ -888,9 +911,7 @@ class PluginFieldsField extends CommonDBTM {
 									//'condition' => '`is_assign`'));								  
 							break;							
 						default:
-						
-
-						
+												
 							Dropdown::show($itemtype, array(
 								  'name'      => $field['name'],
 								  'value'     => $value,
@@ -909,12 +930,8 @@ class PluginFieldsField extends CommonDBTM {
                      }*/
 					 $html.= Dropdown::getDropdownName(getTableNameForForeignKeyField($field['name']),$value);
                   }
-				break;
-               case 'getdate':
-                   $html.= Html::convDateTime($value);
-                  break;
-				  
-				// FIN [CRI] : Insertar nuevos tipos de Objeto y Fecha de sistema				  
+				break;				  
+				// FIN [CRI] : Insertar nuevo tipo de Objeto			  
 				  
             }
             if ($show_table) {
@@ -991,10 +1008,9 @@ class PluginFieldsField extends CommonDBTM {
          'date'         => __("Date", "fields"),
          'datetime'     => __("Date & time", "fields"),
          'dropdownuser' => _n("User", "Users", 2),
-		 // INICIO [CRI] : Insertar nuevos tipos fecha de sistema y tipo objeto
-         'dropdownitem' => _n("Objeto", "Objeto", 2),
-		 'getdate'     => __("Fecha Sistema", "fields")	
-		// FIN [CRI] : Insertar nuevos tipos fecha de sistema y tipo objeto	
+		 // INICIO [CRI] : Insertar nuevo tipo objeto
+         'dropdownitem' => _n("Objeto", "Objeto", 2)
+		// FIN [CRI] : Insertar nuevo tipo objeto	
       ];
    }
 

--- a/inc/labeltranslation.class.php
+++ b/inc/labeltranslation.class.php
@@ -11,6 +11,16 @@ class PluginFieldsLabelTranslation extends CommonDBTM {
     *
     * @return boolean
     */
+// INICIO [CRI] : Crear traducciones y Eliminarlas permanentemente desde el botón eliminar de la traducción
+   static function canCreate() {
+      return self::canUpdate();
+   }	
+   
+   static function canPurge() {  
+      return Session::haveRight(static::$rightname, UPDATE);
+   }   
+// INICIO [CRI] : Crear traducciones y Eliminarlas permanentemente desde el botón eliminar de la traducción
+	
    static function install(Migration $migration, $version) {
       global $DB;
 
@@ -62,7 +72,8 @@ class PluginFieldsLabelTranslation extends CommonDBTM {
       ]);
       return true;
    }
-
+   
+ 
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
       $nb = countElementsInTable(
          self::getTable(),

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -59,7 +59,9 @@ class PluginFieldsMigration extends Migration {
          'yesno'        => 'INT(11)      NOT NULL DEFAULT 0',
          'date'         => 'VARCHAR(255) DEFAULT NULL',
          'datetime'     => 'VARCHAR(255) DEFAULT NULL',
-         'dropdownuser' => 'INT(11)  NOT NULL DEFAULT 0'
+         //'dropdownuser' => 'INT(11)  NOT NULL DEFAULT 0',
+		 'dropdownitem' => 'INT(11)  NOT NULL DEFAULT 0',
+         'getdate' => 'TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP'
       ];
 
       return $types[$field_type];


### PR DESCRIPTION
1º Posibilidad de añadir desplegables de objetos creados mediante Generic Objet. 
2º Posibilidad de Añadir "Condiciones de Filtros" en la definición de los campos. Por ejemplo, que muestre desplegable de Grupos, sólo grupos técnicos (is_assign=1)
3º Posibilidad de eliminar bloques y campos.  (Al eliminarlos el foco vuelve al listado de campos del bloque)
4º Posibilidad de cambiar el nombre de la etiqueta (en traducción) 
6º Permitir que se guarde el campo de tipo Fecha: Los datos de fechas no se guardan en BD.
7º La actualización de un campo adicional en un CI tabbien modifica en campo date_mod del activo.
8º Controlar que los campos name y label al crear un campo nuevo en un bloque no quedan vacíos.