### PR TITLE
fix(core): check if item is entity assign

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
   - 7.2
   - nightly
 
+services:
+  - mysql
+  
 env:
   global:
     - DB=mysql

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -943,7 +943,7 @@ class PluginFieldsContainer extends CommonDBTM {
                      $entities = getSonsOf(getTableForItemType('Entity'), $data['entities_id']);
                   }
 
-                  if (in_array($item->fields['entities_id'], $entities)) {
+                  if (!$item->isEntityAssign() || in_array($item->fields['entities_id'], $entities)) {
                      $tabs_entries[$tab_name] = $tab_label;
                   }
                }
@@ -1365,7 +1365,7 @@ class PluginFieldsContainer extends CommonDBTM {
       $current_entity = $item::getType() == Entity::getType()
                            ? $item->getID()
                            : $item->fields['entities_id'];
-      if (!in_array($current_entity, $entities)) {
+      if ($item->isEntityAssign() && !in_array($current_entity, $entities)) {
          return false;
       }
 

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -554,7 +554,7 @@ class PluginFieldsField extends CommonDBTM {
       $current_entity = $item::getType() == Entity::getType()
                            ? $item->getID()
                            : $item->fields['entities_id'];
-      if (!in_array($current_entity, $entities)) {
+      if ($item->isEntityAssign() && !in_array($current_entity, $entities)) {
          return false;
       }
 


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

Better mangment when item link to container is not assign to entity

Add tab when item is not assign to an entity (entities id not present)
Add dom  when item is not assign to an entity (entities id not present)
Save data when item is not assign to an entity  (entities id not present)

see #347 