### PR TITLE
Fix numeric name

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -90,25 +90,32 @@ class PluginFieldsContainer extends CommonDBTM {
       if ($bad_named_containers->count() > 0) {
          $migration->displayMessage(__("Fix container names", "fields"));
 
+         $toolbox = new PluginFieldsToolbox();
+
          foreach ($bad_named_containers as $container) {
             $old_name = $container['name'];
 
             // Update container name
-            $toolbox = new PluginFieldsToolbox();
-            $container['name'] = $toolbox->getSystemNameFromLabel($container['label']);
+            $new_name = $toolbox->getSystemNameFromLabel($container['label']);
+            foreach (json_decode($container['itemtypes']) as $itemtype) {
+               while (strlen(getTableForItemType(self::getClassname($itemtype, $new_name))) > 64) {
+                  // limit tables names to 64 chars (MySQL limit)
+                  $new_name = substr($new_name, 0, -1);
+               }
+            }
+            $container['name'] = $new_name;
             $container_obj = new PluginFieldsContainer();
             $container_obj->update(
                $container,
                false
             );
 
-            // Rename container tables
+            // Rename container tables and itemtype if needed
             foreach (json_decode($container['itemtypes']) as $itemtype) {
-               $old_table = getTableForItemType(self::getClassname($itemtype, $old_name));
-               $new_table = getTableForItemType(self::getClassname($itemtype, $container['name']));
-               if ($DB->tableExists($old_table)) {
-                  $migration->renameTable($old_table, $new_table);
-               }
+               $migration->renameItemtype(
+                  self::getClassname($itemtype, $old_name),
+                  self::getClassname($itemtype, $new_name)
+               );
             }
          }
       }
@@ -407,6 +414,19 @@ class PluginFieldsContainer extends CommonDBTM {
 
       $toolbox = new PluginFieldsToolbox();
       $input['name'] = $toolbox->getSystemNameFromLabel($input['label']);
+
+      //reject adding when container name is too long for mysql table name
+      foreach ($input['itemtypes'] as $itemtype) {
+         $tmp = getTableForItemType(self::getClassname($itemtype, $input['name']));
+         if (strlen($tmp) > 64) {
+            Session::AddMessageAfterRedirect(
+               __("Container name is too long for database (digits in name are replaced by characters, try to remove them)", 'fields'),
+               false,
+               ERROR
+            );
+            return false;
+         }
+      }
 
       //check for already existing container with same name
       $found = $this->find(['name' => $input['name']]);

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -81,9 +81,18 @@ class PluginFieldsField extends CommonDBTM {
 
 
    function prepareInputForAdd($input) {
-      global $DB;
       //parse name
       $input['name'] = $this->prepareName($input);
+
+      //reject adding when field name is too long for mysql
+      if (strlen($input['name']) > 64) {
+         Session::AddMessageAfterRedirect(
+            __("Field name is too long for database (digits in name are replaced by characters, try to remove them)", 'fields'),
+            false,
+            ERROR
+         );
+         return false;
+      }
 
       if ($input['type'] === "dropdown") {
          //search if dropdown already exist in this container
@@ -97,6 +106,16 @@ class PluginFieldsField extends CommonDBTM {
          //reject adding for same dropdown on same bloc
          if (!empty($found)) {
             Session::AddMessageAfterRedirect(__("You cannot add same field 'dropdown' on same bloc", 'fields', false, ERROR));
+            return false;
+         }
+
+         //reject adding when dropdown name is too long for mysql table name
+         if (strlen(getTableForItemType(PluginFieldsDropdown::getClassname($input['name']))) > 64) {
+            Session::AddMessageAfterRedirect(
+               __("Field name is too long for database (digits in name are replaced by characters, try to remove them)", 'fields'),
+               false,
+               ERROR
+            );
             return false;
          }
 


### PR DESCRIPTION

Add check to prevent usage of field / container name > 64 char after clean by pugin (numeric to string)

Fix migration to prevent usage of table name > 64 char (extract only 64 char if needed) 

see  #344 