### PR TITLE
Bulk-Action update failure: introduce validation if field 'default_value' is set

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -678,7 +678,7 @@ class PluginFieldsField extends CommonDBTM {
             }
 
             //get default value
-            if ($value === "" && $field['default_value'] !== "") {
+            if ($value === "" && isset($field['default_value']) && $field['default_value'] !== "") {
                $value = $field['default_value'];
 
                // shortcut for date/datetime


### PR DESCRIPTION
The Bulk-action "update" is failing for additional fields fo type drop-down.
Error message:
```
Fatal error: Uncaught ErrorException: Undefined index: default_value in /usr/share/glpi/plugins/fields/inc/field.class.php:682 Stack trace: #0 /usr/share/glpi/plugins/fields/inc/field.class.php(682): Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(8, 'Undefined index...', '/usr/share/glpi...', 682, Array) #1 /usr/share/glpi/plugins/fields/inc/field.class.php(868): PluginFieldsField::prepareHtmlFields(Array, 0, 'Computer', true, false, true) #2 /usr/share/glpi/plugins/fields/hook.php(199): PluginFieldsField::showSingle('Computer', Array, true) #3 /usr/share/glpi/inc/plugin.class.php(1196): plugin_fields_MassiveActionsFieldsDisplay(Array) #4 /usr/share/glpi/inc/massiveaction.class.php(859): Plugin::doOneHook('fields', 'plugin_fields_M...', Array) #5 /usr/share/glpi/inc/massiveaction.class.php(619): MassiveAction::showMassiveActionsSubForm(Object(MassiveAction)) #6 /usr/share/glpi/ajax/dropdownMassiveAction.php(48): MassiveAction->showSubForm() #7 {main} thrown in /usr/share/glpi/plugins/fields/inc/field.class.php on line 682
```

Details: values of fields are assigned to different Entities.

Proposed solution:
introduce validation if $field['default_value'] is set.

Kind regards