### PR TITLE
bulk update failing for non existing default_value

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -697,7 +697,7 @@ class PluginFieldsField extends CommonDBTM {
             }
 
             //get default value
-            if ($value === "" && $field['default_value'] !== "") {
+            if ($value === "" && isset($field['default_value']) && $field['default_value'] !== "") {
                $value = $field['default_value'];
 
                // shortcut for date/datetime


### PR DESCRIPTION
The Bulk-action "update" is failing for fields of plugin "fields" because of undefined value $field['default_value']

Error message:
```
Uncaught Exception ErrorException: Undefined index: default_value in /usr/share/glpi/plugins/fields/inc/field.class.php at line 681
```

Affected verion: GLPI 9.5 with Plugin fiels 1.11.0

How to reproduce:
Assign fields from Plugin to object computer and try to perform Bulk Update.

![image](https://user-images.githubusercontent.com/3853721/99946039-ff257300-2d75-11eb-886d-ae6025093290.png)

Solution:
introduce validation if $field['default_value'] is set.

Note: 
This Pull requests is an update for #402 no reproduced on GLPI 9.5 and Plugin 1.11.0.

Thank you