### PR TITLE
Fix extra fields display on creation form

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -544,6 +544,7 @@ class PluginFieldsField extends CommonDBTM {
 
       $subtype = isset($_SESSION['glpi_tabs'][strtolower($item::getType())]) ? $_SESSION['glpi_tabs'][strtolower($item::getType())] : "";
       $type = substr($subtype, -strlen('$main')) === '$main'
+              || in_array('showForm', $functions)
               || in_array('showPrimaryForm', $functions)
               || in_array('showFormHelpdesk', $functions)
                ? 'dom'


### PR DESCRIPTION
Internal ref : !21319.

Extra fields are missing on creation forms if the user's current tab for this itemtype (`$_SESSION['glpi_tabs']`) is not the main one ('$main').

Fix seems to be to add a special case to cover this case like it was done before for the 'showPrimaryForm' and 'showFormHelpdesk' functions.