### PR TITLE
Allow additionnal field edition on solved tickets; closes #426

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -651,7 +651,6 @@ class PluginFieldsField extends CommonDBTM {
          }
 
          if (in_array($items_obj->fields['status'], $items_obj->getClosedStatusArray())
-             || in_array($items_obj->fields['status'], $items_obj->getSolvedStatusArray())
              || $first_found_p['right'] != CREATE) {
             $canedit = false;
          }


### PR DESCRIPTION
Instead of locking fields in status "Resolved", they are now still editable but locked in ticket status "Closed" like in all other tabs - look issue #426 and #128