### PR TITLE
Fix multiple includes in API context; fixes #395

### DIFF
--- a/inc/autoload.php
+++ b/inc/autoload.php
@@ -54,7 +54,7 @@ class PluginFieldsAutoloader
          foreach ($this->paths as $path) {
             $test = $path . DIRECTORY_SEPARATOR . $filename;
             if (file_exists($test)) {
-               return include($test);
+               return include_once($test);
             }
          }
       }


### PR DESCRIPTION
It seems that in API context, autoload may be called multiple times for the same class. I do not know why, maybe it is related to a call using a wrong case.

Using an `include_once` will not fix the source of this problem, but it cannot hurts and it will prevent the mentionned error.