### PR TITLE
Do no use default values for existing items

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -697,7 +697,7 @@ class PluginFieldsField extends CommonDBTM {
             }
 
             //get default value
-            if ($value === "" && $field['default_value'] !== "") {
+            if ($value === "" && $field['default_value'] !== "" && $itemtype::isNewID($items_id)) {
                $value = $field['default_value'];
 
                // shortcut for date/datetime


### PR DESCRIPTION
If you add a new fields with a default value, all existing items will display the default values as the current value.
This is incorrect because there is no value in the database (this values will not show up in the search results for example).

To fix this I've limited the code that load the default value to only work on items not saved in the database yet.

!21971