### PR TITLE
Error when $profile->find() return an empty array

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -918,7 +918,7 @@ class PluginFieldsContainer extends CommonDBTM {
                                   'plugin_fields_containers_id' => $item['id'],
                                   'right' => ['>=', READ]]);
          $first_found = array_shift($found);
-         if ($first_found['right'] == null || $first_found['right'] == 0) {
+         if (isset($first_found['right']) && ($first_found['right'] == null || $first_found['right'] == 0)) {
             continue;
          }
 


### PR DESCRIPTION
Notice: Trying to access array offset on value of type null in L:\inetpub\wwwroot\glpi\plugins\fields\inc\container.class.php on line 921
if $found is empty, $first_found is null and so  $first_found['right'] does not exist

Reproduce: Load page /front/helpdesk.public.php