### PR TITLE
Fix php notice when a container is disabled for all profiles

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -918,7 +918,7 @@ class PluginFieldsContainer extends CommonDBTM {
                                   'plugin_fields_containers_id' => $item['id'],
                                   'right' => ['>=', READ]]);
          $first_found = array_shift($found);
-         if ($first_found['right'] == null || $first_found['right'] == 0) {
+         if (!$first_found || $first_found['right'] == null || $first_found['right'] == 0) {
             continue;
          }
 


### PR DESCRIPTION
Fix this notice:
```
PHP Notice: Trying to access array offset on value of type null
```

This is caused by the result of `array_shift($found);` being null.

https://www.php.net/manual/en/function.array-shift.php
> Returns the shifted value, or null if array is empty or is not an array. 

-> the following condition should take into account that the variable may be null.