### PR TITLE
fix(container): fixing the rights check

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1285,8 +1285,7 @@ class PluginFieldsContainer extends CommonDBTM {
 
       foreach ($itemtypes as $data) {
          $dataitemtypes = json_decode($data['itemtypes']);
-         $item = new $itemtype();
-         if (in_array($item->getType(), $dataitemtypes) != false) {
+         if (in_array($itemtype, $dataitemtypes) != false) {
             $id = $data['id'];
          }
       }


### PR DESCRIPTION
Since release 1.12.1 a bug appears from this PR https://github.com/pluginsGLPI/fields/pull/425

From Dictionnay Software form, it's impossible to add a criteria.
With super-admin profile it's OK 

![image](https://user-images.githubusercontent.com/7335054/130235449-1e2d0f01-d314-422c-a55e-b88074a53840.png)


But with another profile and good right

![image](https://user-images.githubusercontent.com/7335054/130235543-695d8f21-3d88-4eb7-a846-f29f149365d1.png)
 
It's impossible

![image](https://user-images.githubusercontent.com/7335054/130235621-976f0364-395f-4ee3-a9f5-0f0275975182.png)

The "Add" button disappear.

When plugin it's called from this hook

```     
 $PLUGIN_HOOKS['post_item_form']['fields'] = ['PluginFieldsField',  'showForTab'];
```

the plugin tries to find a container for the object being viewed (RuleCriteria in this case)

The hook is called from ```CommonDBTM.class.php```

![image](https://user-images.githubusercontent.com/7335054/130236111-b819c233-a8a9-4b12-bf8c-54c05942fb38.png)

1. Here ```canEdit``` return ```true```
2. Here (after hook) ```can Edit``` return ```false```

When plugin try to find a container related to the object this line break the check process (```canEdit```)

![image](https://user-images.githubusercontent.com/7335054/130236379-beb45fb0-d6c4-4ed6-ae5a-4686043e3930.png)


Here we can check directly the arg (instead of load object), because arg is determined by ```get_class``` function (which use an object)

