### PR TITLE
Fix path check

### DIFF
--- a/front/commondropdown.form.php
+++ b/front/commondropdown.form.php
@@ -3,7 +3,7 @@
 include "../../../inc/includes.php";
 $path = PLUGINFIELDS_FRONT_PATH . '/' . $_REQUEST['ddtype'] . '.form.php';
 $realpath = str_replace( "\\", "/", realpath($path));
-$frontpath = str_replace( "\\", "/", PLUGINFIELDS_FRONT_PATH );
+$frontpath = str_replace("\\", "/", realpath(PLUGINFIELDS_FRONT_PATH));
 if (strpos($realpath, $frontpath) === 0) {
     include_once $path;
 } else {

--- a/front/commondropdown.php
+++ b/front/commondropdown.php
@@ -3,7 +3,7 @@
 include "../../../inc/includes.php";
 $path = PLUGINFIELDS_FRONT_PATH . '/' . $_REQUEST['ddtype'] . '.php';
 $realpath = str_replace( "\\", "/", realpath($path));
-$frontpath = str_replace( "\\", "/", PLUGINFIELDS_FRONT_PATH );
+$frontpath = str_replace("\\", "/", realpath(PLUGINFIELDS_FRONT_PATH));
 if (strpos($realpath, $frontpath) === 0) {
     include_once $path;
 } else {


### PR DESCRIPTION
If you have a mounted disk, the path check will never succeed because the variables will look like this:
```php
$realpath = /mnt/diskhome/home/...
$frontpath = /home/...
```
It seems like `realpath` should be applied to both path we are trying to compare.