### PR TITLE
fix(core): better check to include file from path

### DIFF
--- a/front/commondropdown.form.php
+++ b/front/commondropdown.form.php
@@ -1,11 +1,8 @@
 <?php
 
 include "../../../inc/includes.php";
-$path = PLUGINFIELDS_FRONT_PATH . '/' . $_REQUEST['ddtype'] . '.form.php';
-$realpath = str_replace( "\\", "/", realpath($path));
-$frontpath = str_replace("\\", "/", realpath(PLUGINFIELDS_FRONT_PATH));
-if (strpos($realpath, $frontpath) === 0) {
-    include_once $path;
-} else {
-    throw new \RuntimeException('Attempt to load unsecure or missing ' . $path .'!');
+if (preg_match('/[a-z]/i', $_REQUEST['ddtype']) !== 1) {
+   throw new \RuntimeException(sprintf('Invalid itemtype "%"', $_REQUEST['ddtype']));
 }
+$path = PLUGINFIELDS_FRONT_PATH . '/' . $_REQUEST['ddtype'] . '.form.php';
+require_once $path;

--- a/front/commondropdown.php
+++ b/front/commondropdown.php
@@ -1,11 +1,8 @@
 <?php
 
 include "../../../inc/includes.php";
-$path = PLUGINFIELDS_FRONT_PATH . '/' . $_REQUEST['ddtype'] . '.php';
-$realpath = str_replace( "\\", "/", realpath($path));
-$frontpath = str_replace("\\", "/", realpath(PLUGINFIELDS_FRONT_PATH));
-if (strpos($realpath, $frontpath) === 0) {
-    include_once $path;
-} else {
-    throw new \RuntimeException('Attempt to load unsecure or missing ' . $path .'!');
+if (preg_match('/[a-z]/i', $_REQUEST['ddtype']) !== 1) {
+   throw new \RuntimeException(sprintf('Invalid itemtype "%"', $_REQUEST['ddtype']));
 }
+$path = PLUGINFIELDS_FRONT_PATH . '/' . $_REQUEST['ddtype'] . '.php';
+require_once $path;


### PR DESCRIPTION
From CLOUD context ```RuntimeException``` is throw when we try to go to dropdowns created from fields plugin 

```realpath``` =
 ```/AAA/BBB/CCC/DDD/EEE/glpi_files/_plugins/fields/front/secteurdaffectationfielddropdown.php```

```frontpath``` = 
```/XXX/YYY/CCC/DDD/EEE/glpi_files/_plugins/fields/front```

To prevent load missing or unreadable file just check if it readable or if exist

Internal 23215
