### PR TITLE
fix(UI): prevent name update

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -424,8 +424,10 @@ class PluginFieldsField extends CommonDBTM {
       }
 
       if ($ID > 0) {
+         $attrs = ['readonly' => 'readonly'];
          $edit = true;
       } else {
+         $attrs = [];
          // Create item
          $edit = false;
          $_SESSION['saveInput'] = ['plugin_fields_containers_id' => $container->getField('id')];
@@ -438,7 +440,7 @@ class PluginFieldsField extends CommonDBTM {
       echo "<td>".__("Label")." : </td>";
       echo "<td>";
       echo Html::hidden('plugin_fields_containers_id', ['value' => $container->getField('id')]);
-      Html::autocompletionTextField($this, 'label', ['value' => $this->fields["label"]]);
+      Html::autocompletionTextField($this, 'label', ['value' => $this->fields["label"], 'attrs' => $attrs]);
       echo "</td>";
 
       if (!$edit) {


### PR DESCRIPTION
Currently when you create a field in a container the plugin automatically adds a translation.

But does not prevent the modification of the field label

![image](https://user-images.githubusercontent.com/7335054/153590421-871644e2-a52b-4b9e-a957-a67f08077466.png)

This leads to misunderstanding, as users try to change the wording of the field rather than the translation