### PR TITLE
Fix files regeneration during install

### DIFF
--- a/front/regenerate_files.php
+++ b/front/regenerate_files.php
@@ -33,6 +33,6 @@ include ("../hook.php");
 
 Session::checkRight('entity', READ);
 
-plugin_fields_checkFiles(true);
+plugin_fields_checkFiles();
 
 Html::back();

--- a/hook.php
+++ b/hook.php
@@ -90,9 +90,6 @@ function plugin_fields_install() {
    echo "</tr>";
    echo "</table></center>";
 
-   // Check class and front files for existing containers and dropdown fields
-   plugin_fields_checkFiles(true);
-
    return true;
 }
 

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -45,13 +45,15 @@ class PluginFieldsDropdown {
       $toolbox->fixFieldsNames($migration, ['type' => 'dropdown']);
 
       $migration->displayMessage(__("Updating generated dropdown files", "fields"));
+
+      $obj = new PluginFieldsField;
+      $fields = $obj->find(['type' => 'dropdown']);
+
       // -> 0.90-1.3: generated class moved
       // OLD path: GLPI_ROOT."/plugins/fields/inc/$class_filename"
       // NEW path: PLUGINFIELDS_CLASS_PATH . "/$class_filename"
       // OLD path: GLPI_ROOT."/plugins/fields/front/$class_filename"
       // NEW path: PLUGINFIELDS_FRONT_PATH . "/$class_filename"
-      $obj = new PluginFieldsField;
-      $fields = $obj->find(['type' => 'dropdown']);
       foreach ($fields as $field) {
          //First, drop old fields from plugin directories
          $class_filename = $field['name']."dropdown.class.php";
@@ -68,8 +70,10 @@ class PluginFieldsDropdown {
          if (file_exists(PLUGINFIELDS_DIR."/front/$form_filename")) {
             unlink(PLUGINFIELDS_DIR."/front/$form_filename");
          }
+      }
 
-         //Second, create new files
+      // Regenerate files and install missing tables
+      foreach ($fields as $field) {
          self::create($field);
       }
 

--- a/setup.php
+++ b/setup.php
@@ -221,34 +221,23 @@ function plugin_fields_check_prerequisites() {
  *
  * @return void
  */
-function plugin_fields_checkFiles($force = false) {
+function plugin_fields_checkFiles() {
    global $DB;
 
-   if ($force) {
-      //clean all existing files
-      array_map('unlink', glob(PLUGINFIELDS_DOC_DIR.'/*/*'));
-   }
+   // Clean all existing files
+   array_map('unlink', glob(PLUGINFIELDS_DOC_DIR.'/*/*'));
 
+   // Regenerate containers
    if ($DB->tableExists(PluginFieldsContainer::getTable())) {
       $container_obj = new PluginFieldsContainer();
       $containers    = $container_obj->find();
 
       foreach ($containers as $container) {
-         $itemtypes = (strlen($container['itemtypes']) > 0)
-            ? json_decode($container['itemtypes'], true)
-            : [];
-         foreach ($itemtypes as $itemtype) {
-            $classname = PluginFieldsContainer::getClassname($itemtype, $container['name']);
-            if (!class_exists($classname)) {
-               PluginFieldsContainer::generateTemplate($container);
-            }
-
-            // regenerate table (and fields) also
-            $classname::install($container['id']);
-         }
+         PluginFieldsContainer::create($container);
       }
    }
 
+   // Regenerate dropdowns
    if ($DB->tableExists(PluginFieldsField::getTable())) {
       $fields_obj = new PluginFieldsField();
       $fields     = $fields_obj->find(['type' => 'dropdown']);


### PR DESCRIPTION
During install process, all plugin files were dropped, but none were regenerated, as plugin cannot be active when it is not yet installed.
After a quick analysis, I figured out that files were already regenerated by `PluginFieldsContainer::install()` and `PluginFieldsDropdown::install()`, so I removed call to `plugin_fields_checkFiles()` during install process.

I also simplified `plugin_fields_checkFiles()` which is always called with `$force=true` now. Appropriate session/rights checks are done before calling this method, so there is no need to have checks on session inside it.