### PR TITLE
Fix default itemtype on StatusOverride creation form

### DIFF
--- a/inc/statusoverride.class.php
+++ b/inc/statusoverride.class.php
@@ -356,7 +356,6 @@ class PluginFieldsStatusOverride extends CommonDBTM {
         $twig_params = [
             'container_id'          => $container_id,
             'overrides'             => self::getOverridesForContainer($container_id),
-            'container_itemtypes'   => self::getItemtypesForContainer($container_id)
         ];
         TemplateRenderer::getInstance()->display('@fields/status_overrides.html.twig', $twig_params);
     }

--- a/templates/forms/status_override.html.twig
+++ b/templates/forms/status_override.html.twig
@@ -36,7 +36,7 @@
          <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
             <div class="row flex-row align-items-start flex-grow-1">
                <div class="row flex-row">
-                  {% set itemtype = override.fields['itemtype']|default(container_itemtypes|first) %}
+                  {% set itemtype = override.fields['itemtype']|default(container_itemtypes|keys|first) %}
 
                   {{ fields.dropdownArrayField('itemtype', itemtype, container_itemtypes, __('Item type')) }}
                   {{ fields.dropdownArrayField('plugin_fields_fields_id', itemtype, container_fields, __('Field', 'fields')) }}


### PR DESCRIPTION
Default `itemtype` value was containing the translated itemtype, so the status dropdown returned by the `PluginFieldsStatusOverride::getStatusDropdownForItemtype()` method was always corresponding to the default case.