### PR TITLE
fix(fields): forbidden fields with same type of container itemtypes

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -457,6 +457,8 @@ class PluginFieldsField extends CommonDBTM {
          $_SESSION['saveInput'] = ['plugin_fields_containers_id' => $container->getField('id')];
       }
 
+      $itemtypes_to_exclude = json_decode($container->fields['itemtypes']);
+
       $this->initForm($ID, $options);
       $this->showFormHeader($ID, $options);
 
@@ -477,7 +479,7 @@ class PluginFieldsField extends CommonDBTM {
          echo "<tr>";
          echo "<td>".__("Type")." : </td>";
          echo "<td>";
-         Dropdown::showFromArray('type', self::getTypes(false), ['value' => $this->fields["type"]]);
+         Dropdown::showFromArray('type', self::getTypes(false, $itemtypes_to_exclude), ['value' => $this->fields["type"]]);
          echo "</td>";
       }
       echo "<td>".__("Default values")." : </td>";
@@ -864,7 +866,7 @@ class PluginFieldsField extends CommonDBTM {
       $this->fields['type']      = 'text';
    }
 
-   static function getTypes(bool $flat_list = true) {
+   static function getTypes(bool $flat_list = true,  array $itemtypes_to_exclude = []) {
       global $CFG_GLPI;
 
       $common_types = [
@@ -917,8 +919,23 @@ class PluginFieldsField extends CommonDBTM {
           __('Other')          => $other_types,
       ];
 
+      //remove container itemtypes from list
+      foreach ($itemtypes_to_exclude as $exclude) {
+         self::recursive_unset($all_types, 'dropdown-'.$exclude);
+      }
+
       return $flat_list ? array_merge([], ...array_values($all_types)) : $all_types;
    }
+
+   static function recursive_unset(&$array, $unwanted_key) {
+      unset($array[$unwanted_key]);
+      foreach ($array as &$value) {
+          if (is_array($value)) {
+            self::recursive_unset($value, $unwanted_key);
+          }
+      }
+   }
+
 
    function post_addItem() {
       $input = $this->fields;


### PR DESCRIPTION
Add type (ex : ```dropdown-Computer```) field as same of container itemtypes (ex: ```Computer```) is prohibited