### PR TITLE
Fix handling of regex display condition

### DIFF
--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -418,7 +418,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBTM {
 
     public static function checkRegex($regex) {
         // Avoid php notice when validating the regular expression
-        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
         });
         $isValid = !(preg_match($regex, null) === false);
         restore_error_handler();


### PR DESCRIPTION
On PHP 8.x, `$errcontext` is no more passed to handlers.