### PR TITLE
Fix default dropdown value

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -897,13 +897,17 @@ JAVASCRIPT
          }
 
          //get default value
-         if ($value === null && $field['default_value'] !== "") {
-            $value = $field['default_value'];
+         if  ($value === null) {
+            if ($field['type'] === 'dropdown' && $field['default_value'] === '') {
+                $value = 0;
+            } else if ($field['default_value'] !== "") {
+                $value = $field['default_value'];
 
-            // shortcut for date/datetime
-            if (in_array($field['type'], ['date', 'datetime'])
-                  && $value == 'now') {
-               $value = $_SESSION["glpi_currenttime"];
+                // shortcut for date/datetime
+                if (in_array($field['type'], ['date', 'datetime'])
+                   && $value == 'now') {
+                   $value = $_SESSION["glpi_currenttime"];
+                }
             }
          }
 


### PR DESCRIPTION
If no default is specified in the field config, null was used instead of 0. For at least itemtype dropdowns, instead of showing the empty choice, it would show an empty dropdown. This seemed to be intentional in the core to be able to have no value selected at all, not even the empty choice.

See:
https://github.com/glpi-project/glpi/pull/8682