### PR TITLE
fix(display): do not display tab from template create form

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1025,6 +1025,11 @@ HTML;
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
+        if ($withtemplate) {
+            //Do not display tab from template or from item created from template
+            return [];
+        }
+
         //retrieve container for current tab
         $container = new self();
         $found_c   = $container->find(['type' => 'tab', 'name' => $tabnum, 'is_active' => 1]);


### PR DESCRIPTION
With 'tab' type, 
if main itemtype is created from template, tab is display

![image](https://user-images.githubusercontent.com/7335054/170264554-f20e43a0-214b-4cc8-9a53-ea44180ef6d6.png)

But this behavior not work ATM
