### PR TITLE
Fix overridden mandatory check

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1229,6 +1229,17 @@ HTML;
             'plugin_fields_containers_id' => $data['plugin_fields_containers_id']
         ]);
 
+        // Apply status overrides
+        $status_overrides = $data['status'] !== null
+            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $data['status'])
+            : [];
+        foreach ($status_overrides as $status_override) {
+            if (isset($fields[$status_override['plugin_fields_fields_id']])) {
+                $fields[$status_override['plugin_fields_fields_id']]['is_readonly'] = $status_override['is_readonly'];
+                $fields[$status_override['plugin_fields_fields_id']]['mandatory'] = $status_override['mandatory'];
+            }
+        }
+
         foreach ($fields as $field) {
             if (!$field['is_active']) {
                 continue;
@@ -1514,6 +1525,9 @@ HTML;
            //no ID yet while creating
             $data['items_id'] = $item->getID();
         }
+
+        // Add status so it can be used with status overrides
+        $data['status'] = $item->fields['status'] ?? null;
 
         $has_fields = false;
         foreach ($fields as $field) {

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1229,14 +1229,16 @@ HTML;
             'plugin_fields_containers_id' => $data['plugin_fields_containers_id']
         ]);
 
-        // Apply status overrides
-        $status_overrides = $data['status'] !== null
-            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $data['status'])
-            : [];
-        foreach ($status_overrides as $status_override) {
-            if (isset($fields[$status_override['plugin_fields_fields_id']])) {
-                $fields[$status_override['plugin_fields_fields_id']]['is_readonly'] = $status_override['is_readonly'];
-                $fields[$status_override['plugin_fields_fields_id']]['mandatory'] = $status_override['mandatory'];
+        if (isset($data['items_id'])) { // $data['items_id'] is defined only on update
+            // Apply status overrides
+            $status_overrides = $data['status'] !== null
+                ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $data['status'])
+                : [];
+            foreach ($status_overrides as $status_override) {
+                if (isset($fields[$status_override['plugin_fields_fields_id']])) {
+                    $fields[$status_override['plugin_fields_fields_id']]['is_readonly'] = $status_override['is_readonly'];
+                    $fields[$status_override['plugin_fields_fields_id']]['mandatory'] = $status_override['mandatory'];
+                }
             }
         }
 

--- a/inc/statusoverride.class.php
+++ b/inc/statusoverride.class.php
@@ -198,18 +198,27 @@ class PluginFieldsStatusOverride extends CommonDBChild
 
     public static function getOverridesForItem(int $container_id, CommonDBTM $item): array
     {
-        $status_itemtypes = self::getStatusItemtypes();
-        if (!in_array($item->getType(), $status_itemtypes)) {
+        if (!in_array($item::getType(), self::getStatusItemtypes(), true)) {
             return [];
         }
+
         $status_field_name = self::getStatusFieldName($item->getType());
         $status = $item->fields[$status_field_name];
+        return $status !== null
+           ? self::getOverridesForItemtypeAndStatus($container_id, $item->getType(), $status)
+           : [];
+    }
+
+    public static function getOverridesForItemtypeAndStatus(int $container_id, string $itemtype, int $status): array
+    {
+        if (!in_array($itemtype, self::getStatusItemtypes(), true)) {
+            return [];
+        }
+
         $overrides = self::getOverridesForContainer($container_id);
-        $itemtype = $item->getType();
-        $overrides = array_filter($overrides, static function ($override) use ($itemtype, $status) {
-            return $override['itemtype'] === $itemtype && in_array($status, $override['states']);
+        return array_filter($overrides, static function ($override) use ($itemtype, $status) {
+            return $override['itemtype'] === $itemtype && in_array($status, $override['states'], false);
         });
-        return $overrides;
     }
 
     private static function getItemtypesForContainer(int $container_id): array


### PR DESCRIPTION
When a status override made a non-mandatory field mandatory, the override was not taken into account so blank values were allowed. 