### PR TITLE
Add command to fix incorrectly deleted fields from containers tables

### DIFF
--- a/inc/containertemplate.class.php
+++ b/inc/containertemplate.class.php
@@ -6,7 +6,7 @@ abstract class PluginFieldsContainerTemplate extends CommonDBTM
 
     abstract public static function get_CONTAINER(): string;
 
-    public static function install($containers_id = 0)
+    public static function install()
     {
         global $DB;
 
@@ -31,17 +31,6 @@ abstract class PluginFieldsContainerTemplate extends CommonDBTM
                     (`itemtype`, `items_id`, `plugin_fields_containers_id`)
                 ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
             $DB->query($query) or die($DB->error());
-        }
-
-        // and its fields
-        if ($containers_id) {
-            foreach (
-                $DB->request(PluginFieldsField::getTable(), [
-                    'plugin_fields_containers_id' => $containers_id
-                ]) as $field
-            ) {
-                static::addField($field['name'], $field['type']);
-            }
         }
     }
 
@@ -75,54 +64,5 @@ abstract class PluginFieldsContainerTemplate extends CommonDBTM
         }
 
         $migration->migrationOneTable(static::getTable());
-    }
-
-    public static function unsetUndisclosedFields(&$fields)
-    {
-        parent::unsetUndisclosedFields($fields);
-
-        $base_fields = [
-            "id",
-            "items_id",
-            "itemtype",
-            "plugin_fields_containers_id",
-        ];
-
-        // Remove deleted fields
-        foreach ($fields as $field => $value) {
-            if (in_array($field, $base_fields)) {
-                // Not a custom field; skip
-                continue;
-            }
-
-            $custom_fields = new PluginFieldsField();
-
-            if (preg_match("/plugin_fields_(.*)dropdowns_id/", $field, $matches)) {
-                // Field is a dropdown
-                $data = $custom_fields->find([
-                    'name'                        => $matches[1],
-                    'plugin_fields_containers_id' => $fields['plugin_fields_containers_id'],
-                    'type'                        => "dropdown",
-                    'is_active'                   => 1,
-                ]);
-
-                // This dropdown was deleted, remove it from results
-                if (count($data) == 0) {
-                    unset($fields[$field]);
-                }
-            } else {
-                // Normal field
-                $data = $custom_fields->find([
-                    'name'                        => $field,
-                    'plugin_fields_containers_id' => $fields['plugin_fields_containers_id'],
-                    'is_active'                   => 1,
-                ]);
-
-                // This field was deleted, remove it from results
-                if (count($data) == 0) {
-                    unset($fields[$field]);
-                }
-            }
-        }
     }
 }

--- a/inc/containertemplate.class.php
+++ b/inc/containertemplate.class.php
@@ -1,0 +1,128 @@
+<?php
+
+abstract class PluginFieldsContainerTemplate extends CommonDBTM
+{
+    abstract public static function get_ITEMTYPE(): string;
+
+    abstract public static function get_CONTAINER(): string;
+
+    public static function install($containers_id = 0)
+    {
+        global $DB;
+
+        $default_charset = DBConnection::getDefaultCharset();
+        $default_collation = DBConnection::getDefaultCollation();
+        $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+        $obj = new static();
+        $table = $obj->getTable();
+
+        // create Table
+        $itemtype =  static::get_ITEMTYPE();
+        $container =  static::get_CONTAINER();
+        if (!$DB->tableExists($table)) {
+             $query = "CREATE TABLE IF NOT EXISTS `$table` (
+                `id`                               INT          {$default_key_sign} NOT NULL auto_increment,
+                `items_id`                         INT          {$default_key_sign} NOT NULL,
+                `itemtype`                         VARCHAR(255) DEFAULT '$itemtype',
+                `plugin_fields_containers_id`      INT          {$default_key_sign} NOT NULL DEFAULT '$container',
+                PRIMARY KEY                        (`id`),
+                UNIQUE INDEX `itemtype_item_container`
+                    (`itemtype`, `items_id`, `plugin_fields_containers_id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
+            $DB->query($query) or die($DB->error());
+        }
+
+        // and its fields
+        if ($containers_id) {
+            foreach (
+                $DB->request(PluginFieldsField::getTable(), [
+                    'plugin_fields_containers_id' => $containers_id
+                ]) as $field
+            ) {
+                static::addField($field['name'], $field['type']);
+            }
+        }
+    }
+
+    public static function uninstall()
+    {
+        global $DB;
+
+        $obj = new static();
+        return $DB->query("DROP TABLE IF EXISTS `" . $obj->getTable() . "`");
+    }
+
+    public static function addField($fieldname, $type)
+    {
+        $migration = new PluginFieldsMigration(0);
+
+        $sql_fields = PluginFieldsMigration::getSQLFields($fieldname, $type);
+        foreach ($sql_fields as $sql_field_name => $sql_field_type) {
+            $migration->addField(static::getTable(), $sql_field_name, $sql_field_type);
+        }
+
+        $migration->migrationOneTable(static::getTable());
+    }
+
+    public static function removeField($fieldname, $type)
+    {
+        $migration = new PluginFieldsMigration(0);
+
+        $sql_fields = PluginFieldsMigration::getSQLFields($fieldname, $type);
+        foreach (array_keys($sql_fields) as $sql_field_name) {
+            $migration->dropField(static::getTable(), $sql_field_name);
+        }
+
+        $migration->migrationOneTable(static::getTable());
+    }
+
+    public static function unsetUndisclosedFields(&$fields)
+    {
+        parent::unsetUndisclosedFields($fields);
+
+        $base_fields = [
+            "id",
+            "items_id",
+            "itemtype",
+            "plugin_fields_containers_id",
+        ];
+
+        // Remove deleted fields
+        foreach ($fields as $field => $value) {
+            if (in_array($field, $base_fields)) {
+                // Not a custom field; skip
+                continue;
+            }
+
+            $custom_fields = new PluginFieldsField();
+
+            if (preg_match("/plugin_fields_(.*)dropdowns_id/", $field, $matches)) {
+                // Field is a dropdown
+                $data = $custom_fields->find([
+                    'name'                        => $matches[1],
+                    'plugin_fields_containers_id' => $fields['plugin_fields_containers_id'],
+                    'type'                        => "dropdown",
+                    'is_active'                   => 1,
+                ]);
+
+                // This dropdown was deleted, remove it from results
+                if (count($data) == 0) {
+                    unset($fields[$field]);
+                }
+            } else {
+                // Normal field
+                $data = $custom_fields->find([
+                    'name'                        => $field,
+                    'plugin_fields_containers_id' => $fields['plugin_fields_containers_id'],
+                    'is_active'                   => 1,
+                ]);
+
+                // This field was deleted, remove it from results
+                if (count($data) == 0) {
+                    unset($fields[$field]);
+                }
+            }
+        }
+    }
+}

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -171,10 +171,6 @@ class PluginFieldsField extends CommonDBChild {
             );
             return false;
          }
-
-         $oldname = $input['name'];
-         $input['name'] = getForeignKeyFieldForItemType(
-            PluginFieldsDropdown::getClassname($input['name']));
       }
 
       // Before adding, add the ranking of the new field
@@ -192,10 +188,6 @@ class PluginFieldsField extends CommonDBChild {
          }
       }
 
-      if (isset($oldname)) {
-         $input['name'] = $oldname;
-      }
-
       if (isset($input['allowed_values'])) {
          $input['allowed_values'] = Sanitizer::dbEscape(json_encode($input['allowed_values']));
       }
@@ -210,12 +202,6 @@ class PluginFieldsField extends CommonDBChild {
       if ($this->fields['type'] !== "header"
           && !isset($_SESSION['uninstall_fields'])
           && !isset($_SESSION['delete_container'])) {
-
-         if ($this->fields['type'] === "dropdown") {
-            $oldname = $this->fields['name'];
-            $this->fields['name'] = getForeignKeyFieldForItemType(
-               PluginFieldsDropdown::getClassname($this->fields['name']));
-         }
 
          $container_obj = new PluginFieldsContainer;
          $container_obj->getFromDB($this->fields['plugin_fields_containers_id']);
@@ -232,10 +218,6 @@ class PluginFieldsField extends CommonDBChild {
          'itemtype' => self::getType(),
          'items_id' => $this->fields['id']
       ]);
-
-      if (isset($oldname)) {
-         $this->fields['name'] = $oldname;
-      }
 
       if ($this->fields['type'] === "dropdown") {
          return PluginFieldsDropdown::destroy($this->fields['name']);

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -220,6 +220,7 @@ class PluginFieldsField extends CommonDBChild {
          $container_obj = new PluginFieldsContainer;
          $container_obj->getFromDB($this->fields['plugin_fields_containers_id']);
          foreach (json_decode($container_obj->fields['itemtypes']) as $itemtype) {
+
             $classname = PluginFieldsContainer::getClassname($itemtype, $container_obj->fields['name']);
             $classname::removeField($this->fields['name'], $this->fields['type']);
          }

--- a/inc/fixdroppedfieldscommand.class.php
+++ b/inc/fixdroppedfieldscommand.class.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Fields plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Fields.
+ *
+ * Fields is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Fields is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fields. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2013-2022 by Fields plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/fields
+ * -------------------------------------------------------------------------
+ */
+
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PluginFieldsFixDroppedFieldsCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        $this->setName('plugin:fields:fixdroppedfields');
+        $this->setAliases(['fields:fixdroppedfields']);
+        $this->setDescription(
+            'Remove fields that were wrongly kept in the database following an '
+            . 'issue introduced in 1.15.0 and fixed in 1.15.3.'
+        );
+
+        $this->addOption(
+            "delete",
+            null,
+            InputOption::VALUE_NONE,
+            "Use this option to actually delete data"
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Read option
+        $delete = $input->getOption("delete");
+
+        $fields = PluginFieldsMigration::fixDroppedFields(!$delete);
+
+        // No invalid fields found
+        if (!count($fields)) {
+            $output->writeln(
+                __("Everything is in order - no action needed.", 'fields'),
+            );
+            return Command::SUCCESS;
+        }
+
+        // Indicate which fields will have been or must be deleted
+        foreach ($fields as $field) {
+            if ($delete) {
+                $info = sprintf(__("-> %s was deleted.", 'fields'), $field);
+            } else {
+                $info = sprintf(__("-> %s must be deleted.", 'fields'), $field);
+            }
+
+            $output->writeln($info);
+        }
+
+        // Show extra info in dry-run mode
+        if (!$delete) {
+            $fields_found = sprintf(
+                __("%s field(s) need to be deleted.", 'fields'),
+                count($fields)
+            );
+            $output->writeln($fields_found);
+
+            // Print command to do the actual deletion
+            $next_command = sprintf(
+                __("Run \"%s\" to delete the found field(s).", 'fields'),
+                "php bin/console plugin:fields:fixdroppedfields --delete"
+            );
+            $output->writeln($next_command);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -28,96 +28,227 @@
  * -------------------------------------------------------------------------
  */
 
-class PluginFieldsMigration extends Migration {
+class PluginFieldsMigration extends Migration
+{
+    public function __construct($ver = "")
+    {
+        parent::__construct($ver);
+    }
 
-   function __construct($ver = "") {
-      parent::__construct($ver);
-   }
+    public static function install(Migration $migration, $version)
+    {
+        global $DB;
 
-   static function install(Migration $migration, $version) {
-      global $DB;
+        $fields_migration = new self();
 
-      $fields_migration = new self;
+        if ($DB->tableExists("glpi_plugin_customfields_fields")) {
+            if (!$fields_migration->updateFromCustomfields()) {
+                return false;
+            }
+        }
 
-      if ($DB->tableExists("glpi_plugin_customfields_fields")) {
-         if (!$fields_migration->updateFromCustomfields()) {
-            return false;
-         }
-      }
+        return true;
+    }
 
-      return true;
-   }
+    public static function uninstall()
+    {
+        return true;
+    }
 
-   static function uninstall() {
-      return true;
-   }
+    public function updateFromCustomfields($glpi_version = "0.80")
+    {
+        //TODO : REWRITE customfield update
+        return true;
+    }
 
-   function updateFromCustomfields($glpi_version = "0.80") {
-      //TODO : REWRITE customfield update
-      return true;
-   }
+    public function displayMessage($msg)
+    {
+        Session::addMessageAfterRedirect($msg);
+    }
 
-   function displayMessage($msg) {
-      Session::addMessageAfterRedirect($msg);
-   }
+    public function migrateCustomfieldTypes($old_type)
+    {
+        $types = [
+            'sectionhead' => 'header',
+            'general'     => 'text',
+            'money'       => 'text',
+            'note'        => 'textarea',
+            'text'        => 'textarea',
+            'number'      => 'number',
+            'dropdown'    => 'dropdown',
+            'yesno'       => 'yesno',
+            'date'        => 'date'
+        ];
 
-   function migrateCustomfieldTypes($old_type) {
-      $types = [
-         'sectionhead' => 'header',
-         'general'     => 'text',
-         'money'       => 'text',
-         'note'        => 'textarea',
-         'text'        => 'textarea',
-         'number'      => 'number',
-         'dropdown'    => 'dropdown',
-         'yesno'       => 'yesno',
-         'date'        => 'date'
-      ];
+        return $types[$old_type];
+    }
 
-      return $types[$old_type];
-   }
+    /**
+     * Return SQL fields corresponding to given additionnal field.
+     *
+     * @param string $field_name
+     * @param string $field_type
+     *
+     * @return array
+     */
+    public static function getSQLFields(
+        string $field_name,
+        string $field_type
+    ): array {
+        $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-   /**
-    * Return SQL fields corresponding to given additionnal field.
-    *
-    * @param string $field_name
-    * @param string $field_type
-    *
-    * @return array
-    */
-   public static function getSQLFields(string $field_name, string $field_type): array {
+        $fields = [];
+        switch (true) {
+            case $field_type === 'header':
+                // header type is for read-only display purpose only and has no SQL field
+                break;
+            case $field_type === 'dropdown':
+                // Compute dropdown field name
+                $field_name = getForeignKeyFieldForItemType(
+                    PluginFieldsDropdown::getClassname($field_name)
+                );
+                $fields[$field_name] = "INT {$default_key_sign} NOT NULL DEFAULT 0";
+                break;
+            case $field_type === 'textarea':
+            case $field_type === 'url':
+                $fields[$field_name] = 'TEXT DEFAULT NULL';
+                break;
+            case $field_type === 'yesno':
+                $fields[$field_name] = 'INT NOT NULL DEFAULT 0';
+                break;
+            case $field_type === 'glpi_item':
+                $fields[sprintf('itemtype_%s', $field_name)] = 'varchar(100) NOT NULL';
+                $fields[sprintf('items_id_%s', $field_name)] = "int {$default_key_sign} NOT NULL DEFAULT 0";
+                break;
+            case $field_type === 'date':
+            case $field_type === 'datetime':
+            case $field_type === 'number':
+            case $field_type === 'text':
+            default:
+                $fields[$field_name] = 'VARCHAR(255) DEFAULT NULL';
+                break;
+        }
 
-      $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+        return $fields;
+    }
 
-      $fields = [];
-      switch (true) {
-         case $field_type === 'header':
-            // header type is for read-only display purpose only and has no SQL field
-            break;
-         case $field_type === 'dropdown':
-         case preg_match('/^dropdown-.+/i', $field_type):
-            $fields[$field_name] = "INT {$default_key_sign} NOT NULL DEFAULT 0";
-            break;
-         case $field_type === 'textarea':
-         case $field_type === 'url':
-            $fields[$field_name] = 'TEXT DEFAULT NULL';
-            break;
-         case $field_type === 'yesno':
-            $fields[$field_name] = 'INT NOT NULL DEFAULT 0';
-            break;
-         case $field_type === 'glpi_item':
-            $fields[sprintf('itemtype_%s', $field_name)] = 'varchar(100) NOT NULL';
-            $fields[sprintf('items_id_%s', $field_name)] = "int {$default_key_sign} NOT NULL DEFAULT 0";
-            break;
-         case $field_type === 'date':
-         case $field_type === 'datetime':
-         case $field_type === 'number':
-         case $field_type === 'text':
-         default:
-            $fields[$field_name] = 'VARCHAR(255) DEFAULT NULL';
-            break;
-      }
+    /**
+     * An issue affected field removal in 1.15.0, 1.15.1 and 1.15.2.
+     * Using these versions, removing a field from a container would drop the
+     * field from glpi_plugin_fields_fields but not from the custom container
+     * table
+     *
+     * This function find looks into containers tables for these fields that
+     * should have been removed and list them (dry_run = true) or delete them
+     * (dry_run = false)
+     *
+     * @param bool $dry_run
+     *
+     * @return array
+     */
+    public static function fixDroppedFields(bool $dry_run = true): array
+    {
+        /** @var DBMysql $DB */
+        global $DB;
 
-      return $fields;
-   }
+        // Keep track of dropped fields
+        $dropped = [];
+
+        // For each existing container
+        foreach ((new PluginFieldsContainer())->find([]) as $row) {
+            // Get expected fields
+            $valid_fields = self::getValidFieldsForContainer($row['id']);
+
+            // Read itemtypes and container name
+            $itemtypes = importArrayFromDB($row['itemtypes']);
+            $name = $row['name'];
+
+            // One table to handle per itemtype
+            foreach ($itemtypes as $itemtype) {
+                // Build table name
+                $table = getTableForItemType("PluginFields{$itemtype}{$name}");
+
+                if (!$DB->tableExists($table)) {
+                    // Missing table; skip (abnormal)
+                    continue;
+                }
+
+                // Get the actual fields defined in the container table
+                $found_fields = self::getCustomFieldsInContainerTable($table);
+
+                // Compute which fields should be removed
+                $fields_to_drop = array_diff($found_fields, $valid_fields);
+
+                // Drop fields
+                $migration = new PluginFieldsMigration(0);
+
+                foreach ($fields_to_drop as $field) {
+                    $dropped[] = "$table.$field";
+                    $migration->dropField($table, $field);
+                }
+
+                if (!$dry_run) {
+                    $migration->migrationOneTable($table);
+                }
+            }
+        }
+
+        return $dropped;
+    }
+
+    /**
+     * Get all fields defined for a container in glpi_plugin_fields_fields
+     *
+     * @param int $container_id Id of the container
+     *
+     * @return array
+     */
+    private static function getValidFieldsForContainer(int $container_id): array
+    {
+        // Keep track of fields found
+        $valid_fields = [];
+
+        // For each defined fields in the given container
+        foreach (
+            (new PluginFieldsField())->find([
+                'plugin_fields_containers_id' => $container_id
+            ]) as $row
+        ) {
+            $fields = self::getSQLFields($row['name'], $row['type']);
+            array_push($valid_fields, ...array_keys($fields));
+        }
+
+        return $valid_fields;
+    }
+
+    /**
+     * Get custom fields in a given container table
+     * This means all fields found in the table expect those defined in
+     * $basic_fields
+     *
+     * @param string $table
+     *
+     * @return array
+     */
+    private static function getCustomFieldsInContainerTable(
+        string $table
+    ): array {
+        /** @var DBMysql $DB */
+        global $DB;
+
+        // Read table fields
+        $fields = $DB->listFields($table);
+
+        // Reduce to fields name only
+        $fields = array_column($fields, "Field");
+
+        // Remove basic fields
+        $basic_fields = [
+            'id',
+            'items_id',
+            'itemtype',
+            'plugin_fields_containers_id',
+        ];
+        return array_filter($fields, fn($f) => !in_array($f, $basic_fields));
+    }
 }

--- a/templates/container.class.tpl
+++ b/templates/container.class.tpl
@@ -1,69 +1,16 @@
 <?php
 
-class %%CLASSNAME%% extends CommonDBTM
+class %%CLASSNAME%% extends PluginFieldsContainerTemplate
 {
-   static $rightname = '%%ITEMTYPE_RIGHT%%';
+    static $rightname = '%%ITEMTYPE_RIGHT%%';
 
-   static function install($containers_id = 0) {
-      global $DB;
+    public static function get_ITEMTYPE(): string
+    {
+        return '%%ITEMTYPE%%';
+    }
 
-      $default_charset = DBConnection::getDefaultCharset();
-      $default_collation = DBConnection::getDefaultCollation();
-      $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
-
-      $obj = new self();
-      $table = $obj->getTable();
-
-      // create Table
-      if (!$DB->tableExists($table)) {
-         $query = "CREATE TABLE IF NOT EXISTS `$table` (
-                  `id`                               INT          {$default_key_sign} NOT NULL auto_increment,
-                  `items_id`                         INT          {$default_key_sign} NOT NULL,
-                  `itemtype`                         VARCHAR(255) DEFAULT '%%ITEMTYPE%%',
-                  `plugin_fields_containers_id`      INT          {$default_key_sign} NOT NULL DEFAULT '%%CONTAINER%%',
-                  PRIMARY KEY                        (`id`),
-                  UNIQUE INDEX `itemtype_item_container`
-                     (`itemtype`, `items_id`, `plugin_fields_containers_id`)
-               ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
-         $DB->query($query) or die ($DB->error());
-      }
-
-      // and its fields
-      if ($containers_id) {
-         foreach ($DB->request(PluginFieldsField::getTable(), [
-            'plugin_fields_containers_id' => $containers_id
-         ]) as $field) {
-            self::addField($field['name'], $field['type']);
-         }
-      }
-   }
-
-   static function uninstall() {
-      global $DB;
-
-      $obj = new self();
-      return $DB->query("DROP TABLE IF EXISTS `".$obj->getTable()."`");
-   }
-
-   static function addField($fieldname, $type) {
-      $migration = new PluginFieldsMigration(0);
-
-      $sql_fields = PluginFieldsMigration::getSQLFields($fieldname, $type);
-      foreach ($sql_fields as $sql_field_name => $sql_field_type) {
-         $migration->addField(self::getTable(), $sql_field_name, $sql_field_type);
-      }
-
-      $migration->migrationOneTable(self::getTable());
-   }
-
-   static function removeField($fieldname, $type) {
-      $migration = new PluginFieldsMigration(0);
-
-      $sql_fields = PluginFieldsMigration::getSQLFields($fieldname, $type);
-      foreach (array_keys($sql_fields) as $sql_field_name) {
-         $migration->dropField(self::getTable(), $sql_field_name);
-      }
-
-      $migration->migrationOneTable(self::getTable());
-   }
+    public static function get_CONTAINER(): string
+    {
+        return '%%CONTAINER%%';
+    }
 }


### PR DESCRIPTION
Internal ref: !24075.

EDITED after #526 (see comments)

An issue affected field removal in 1.15.0, 1.15.1 and 1.15.2.
Using these versions, removing a field from a container would drop the field from glpi_plugin_fields_fields but not from the custom container table.

This command remove these incorrectly deleted fields.

Command examples:
![image](https://user-images.githubusercontent.com/42734840/171640175-a8ed6bb2-be7e-4e0a-9bd5-785ed2b1c9e9.png)

Unrelated changes kept from the previous iteration:
* Add `PluginFieldsContainerTemplate` base class for custom containers classes in order to reduce the generated php classes for each containers.

The main advantage is that you can edit the generic code directly from `PluginFieldsContainerTemplate` and it will impact all custom container classes without having to "regenerate" the PHP files of these custom classes.




