### PR TITLE
fix(glpi_item): add default value to prevent error when field is not filled

### DIFF
--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -67,7 +67,7 @@ class PluginFieldsMigration extends Migration
                 $fields[$field_name] = 'INT NOT NULL DEFAULT 0';
                 break;
             case $field_type === 'glpi_item':
-                $fields[sprintf('itemtype_%s', $field_name)] = 'varchar(100) NOT NULL';
+                $fields[sprintf('itemtype_%s', $field_name)] = "varchar(100) NOT NULL DEFAULT ''";
                 $fields[sprintf('items_id_%s', $field_name)] = "int {$default_key_sign} NOT NULL DEFAULT 0";
                 break;
             case $field_type === 'date':

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -67,7 +67,7 @@ class PluginFieldsMigration extends Migration
                 $fields[$field_name] = 'INT NOT NULL DEFAULT 0';
                 break;
             case $field_type === 'glpi_item':
-                $fields[sprintf('itemtype_%s', $field_name)] = "varchar(100) DEFAULT NULL";
+                $fields[sprintf('itemtype_%s', $field_name)] = 'varchar(100) DEFAULT NULL';
                 $fields[sprintf('items_id_%s', $field_name)] = "int {$default_key_sign} NOT NULL DEFAULT 0";
                 break;
             case $field_type === 'date':

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -67,7 +67,7 @@ class PluginFieldsMigration extends Migration
                 $fields[$field_name] = 'INT NOT NULL DEFAULT 0';
                 break;
             case $field_type === 'glpi_item':
-                $fields[sprintf('itemtype_%s', $field_name)] = "varchar(100) NOT NULL DEFAULT ''";
+                $fields[sprintf('itemtype_%s', $field_name)] = "varchar(100) DEFAULT NULL";
                 $fields[sprintf('items_id_%s', $field_name)] = "int {$default_key_sign} NOT NULL DEFAULT 0";
                 break;
             case $field_type === 'date':

--- a/templates/container.class.tpl
+++ b/templates/container.class.tpl
@@ -10,7 +10,6 @@ class %%CLASSNAME%% extends CommonDBTM
       $default_charset = DBConnection::getDefaultCharset();
       $default_collation = DBConnection::getDefaultCollation();
       $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
-      $migration = new PluginFieldsMigration(0);
 
       $obj = new self();
       $table = $obj->getTable();
@@ -28,16 +27,21 @@ class %%CLASSNAME%% extends CommonDBTM
                ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
          $DB->query($query) or die ($DB->error());
       } else {
+         // 1.15.4
+         // fix nullable state for 'glpi_item' field
          $result = $DB->query("SHOW COLUMNS FROM `$table`");
-         if ($result) {
-            if ($DB->numrows($result) > 0) {
-               while ($data = $DB->fetchAssoc($result)) {
-                  //set default value for type 'glpi_item'
-                  if (str_starts_with($data['Field'], 'itemtype_') && $data['Default'] != 'NULL') {
-                     $migration->changeField($table, $data['Field'], $data['Field'], "varchar(100) DEFAULT NULL");
-                     $migration->migrationOneTable(self::getTable());
-                  }
+         if ($result && $DB->numrows($result) > 0) {
+            $changed = false;
+            $migration = new PluginFieldsMigration(0);
+            while ($data = $DB->fetchAssoc($result)) {
+               if (str_starts_with($data['Field'], 'itemtype_') && $data['Null'] !== 'YES') {
+               Toolbox::logDebug($data);
+                  $migration->changeField($table, $data['Field'], $data['Field'], "varchar(100) DEFAULT NULL");
+                  $changed = true;
                }
+            }
+            if ($changed) {
+               $migration->executeMigration();
             }
          }
       }

--- a/templates/container.class.tpl
+++ b/templates/container.class.tpl
@@ -33,8 +33,8 @@ class %%CLASSNAME%% extends CommonDBTM
             if ($DB->numrows($result) > 0) {
                while ($data = $DB->fetchAssoc($result)) {
                   //set default value for type 'glpi_item'
-                  if (str_starts_with($data['Field'], 'itemtype_') ) {
-                     $migration->changeField($table, $data['Field'], $data['Field'], "varchar(100) NOT NULL DEFAULT ''");
+                  if (str_starts_with($data['Field'], 'itemtype_')) {
+                     $migration->changeField($table, $data['Field'], $data['Field'], "varchar(100) DEFAULT NULL");
                      $migration->migrationOneTable(self::getTable());
                   }
                }

--- a/templates/container.class.tpl
+++ b/templates/container.class.tpl
@@ -33,7 +33,7 @@ class %%CLASSNAME%% extends CommonDBTM
             if ($DB->numrows($result) > 0) {
                while ($data = $DB->fetchAssoc($result)) {
                   //set default value for type 'glpi_item'
-                  if (str_starts_with($data['Field'], 'itemtype_')) {
+                  if (str_starts_with($data['Field'], 'itemtype_') && $data['Default'] != 'NULL') {
                      $migration->changeField($table, $data['Field'], $data['Field'], "varchar(100) DEFAULT NULL");
                      $migration->migrationOneTable(self::getTable());
                   }


### PR DESCRIPTION
Add default value to prevent SQL error when field ```glpi_item``` is not filled

```sql
[2022-06-08 10:15:16] glpisqllog.ERROR: DBmysql::query() in /home/stanislas/Teclib/dev/GLPI/10.0-bugfixes/src/DBmysql.php line 370
  *** MySQL query error:
  SQL: INSERT INTO `glpi_plugin_fields_ticketbloc` (`plugin_fields_containers_id`, `items_id`, `plugin_fields_customdropdownfielddropdowns_id`, `nativetextfield`, `nativedatefield`, `nativedatetimefield`, `nativeyesnofield`, `nativeuserfield`) VALUES ('5', '10', '2', 'titi', '2022-06-07', '2022-06-07 10:14:42', '1', '2')
  Error: Field 'itemtype_glpiitemfield' doesn't have a default value
  Backtrace :
  src/DBmysql.php:1312                               
  src/CommonDBTM.php:705                             DBmysql->insert()
  src/CommonDBTM.php:1297                            CommonDBTM->addToDB()
  plugins/fields/inc/container.class.php:1068        CommonDBTM->add()
  plugins/fields/inc/container.class.php:1424        PluginFieldsContainer->updateFieldsValues()
  src/Plugin.php:1454                                PluginFieldsContainer::preItemUpdate()
  src/CommonDBTM.php:1563                            Plugin::doHook()
  front/ticket.form.php:84                           CommonDBTM->update()
  {"user":"2@Desktop","mem_usage":"0.006\", 4.37Mio)"} 
```