### PR TITLE
Fix mandatory restriction on Number field type

### DIFF
--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -60,7 +60,7 @@
         {{ macros.textField(name, value, label, field_options) }}
 
     {% elseif type == 'number' %}
-        {{ macros.numberField(name, value, label, field_options|merge({step: 'any'})) }}
+        {{ macros.numberField(name, value, label, field_options|merge({step: 'any', min: ''})) }}
 
     {% elseif type == 'url' %}
             {% set ext_link %}


### PR DESCRIPTION
It is not possible to enforce “Number” type field to be mandatory in GLPIV10 in Fields plugin. This was still possible in V9.5 and stopped working due to changes in V10.
Even when field is marked as mandatory user is never asked to enter or update/fill in the field.
The number field always have default value 0 as this is enforced by core GLPI code in twig macros:

https://github.com/glpi-project/glpi/blob/dccc79cd305e96b272ff12f0b76914ced4b198af/templates/components/form/fields_macros.html.twig#L153

I would like to avoid this and leave number field without any default value so user is enforced to enter it.
If believe this would be probably unacceptable for GLPI team to make it empty for whole GLPI.
So I propose following PR for fields: pass min value so it is empty not 0, if default is not specified by user