### PR TITLE
fix: correct spelling of plugin name

### DIFF
--- a/front/container.form.php
+++ b/front/container.form.php
@@ -57,7 +57,7 @@ if (isset($_POST["add"])) {
     Html::back();
 } else {
     Html::header(
-        __("Additionnal fields", "fields"),
+        __("Additional fields", "fields"),
         $_SERVER['PHP_SELF'],
         "config",
         "pluginfieldsmenu",

--- a/front/container.php
+++ b/front/container.php
@@ -31,7 +31,7 @@
 include("../../../inc/includes.php");
 
 Html::header(
-    __("Additionnal fields", "fields"),
+    __("Additional fields", "fields"),
     $_SERVER['PHP_SELF'],
     "config",
     "pluginfieldsmenu",

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -34,7 +34,7 @@ class PluginFieldsMenu extends CommonGLPI
 
     public static function getMenuName()
     {
-        return __("Additionnal fields", "fields");
+        return __("Additional fields", "fields");
     }
 
     public static function getMenuContent()

--- a/locales/cs_CZ.po
+++ b/locales/cs_CZ.po
@@ -38,7 +38,7 @@ msgstr "Přidat tabulku"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Další kolonky"
 
 #: inc/field.class.php:546

--- a/locales/en_GB.po
+++ b/locales/en_GB.po
@@ -35,8 +35,8 @@ msgstr "Add tab"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
-msgstr "Additionnal fields"
+msgid "Additional fields"
+msgstr "Additional fields"
 
 #: inc/field.class.php:546
 msgid "Allowed values"

--- a/locales/en_US.po
+++ b/locales/en_US.po
@@ -38,7 +38,7 @@ msgstr "Add Tab"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Additional Fields"
 
 #: inc/field.class.php:546

--- a/locales/es_ES.po
+++ b/locales/es_ES.po
@@ -41,7 +41,7 @@ msgstr "Agregar pestaña"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Campos adicionales"
 
 #: inc/field.class.php:546

--- a/locales/fi_FI.po
+++ b/locales/fi_FI.po
@@ -37,7 +37,7 @@ msgstr "Lisää välilehti"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Lisäkentät"
 
 #: inc/field.class.php:546

--- a/locales/fields.pot
+++ b/locales/fields.pot
@@ -36,7 +36,7 @@ msgstr ""
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr ""
 
 #: inc/field.class.php:546

--- a/locales/fr_FR.po
+++ b/locales/fr_FR.po
@@ -40,7 +40,7 @@ msgstr "Ajout d'un onglet"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Champs supplémentaires"
 
 #: inc/field.class.php:546

--- a/locales/hr_HR.po
+++ b/locales/hr_HR.po
@@ -38,7 +38,7 @@ msgstr "Dodaj karticu"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Dodatna polja"
 
 #: inc/field.class.php:546

--- a/locales/it_IT.po
+++ b/locales/it_IT.po
@@ -36,7 +36,7 @@ msgstr "Aggiungi scheda"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Campi aggiuntivi"
 
 #: inc/field.class.php:546

--- a/locales/ja_JP.po
+++ b/locales/ja_JP.po
@@ -37,7 +37,7 @@ msgstr "タブを追加する"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "追加のフィールド"
 
 #: inc/field.class.php:546

--- a/locales/ko_KR.po
+++ b/locales/ko_KR.po
@@ -36,7 +36,7 @@ msgstr "탭 추가"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "추가 항목"
 
 #: inc/field.class.php:546

--- a/locales/pl_PL.po
+++ b/locales/pl_PL.po
@@ -37,7 +37,7 @@ msgstr "Dodaj zakładkę"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Dodatkowe pola"
 
 #: inc/field.class.php:546

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -41,7 +41,7 @@ msgstr "Adicionar aba"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Campos adicionais"
 
 #: inc/field.class.php:546

--- a/locales/pt_PT.po
+++ b/locales/pt_PT.po
@@ -35,7 +35,7 @@ msgstr "Adicionar aba"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Campos adicionais"
 
 #: inc/field.class.php:546

--- a/locales/ro_RO.po
+++ b/locales/ro_RO.po
@@ -37,7 +37,7 @@ msgstr "Add tab"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Campuri aditionale"
 
 #: inc/field.class.php:546

--- a/locales/ru_RU.po
+++ b/locales/ru_RU.po
@@ -40,7 +40,7 @@ msgstr "Добавить вкладку"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Дополнительные поля"
 
 #: inc/field.class.php:546

--- a/locales/tr_TR.po
+++ b/locales/tr_TR.po
@@ -36,7 +36,7 @@ msgstr "Sekme ekle"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Ek alanlar"
 
 #: inc/field.class.php:546

--- a/locales/uk_UA.po
+++ b/locales/uk_UA.po
@@ -36,7 +36,7 @@ msgstr "Додати закладку"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "Додаткові поля"
 
 #: inc/field.class.php:546

--- a/locales/zh_CN.po
+++ b/locales/zh_CN.po
@@ -36,7 +36,7 @@ msgstr "添加标签"
 
 #: front/container.form.php:64 front/container.php:33 inc/menu.class.php:35
 #: setup.php:189
-msgid "Additionnal fields"
+msgid "Additional fields"
 msgstr "附加字段"
 
 #: inc/field.class.php:546

--- a/setup.php
+++ b/setup.php
@@ -199,7 +199,7 @@ function plugin_init_fields()
 function plugin_version_fields()
 {
     return [
-        'name'           => __("Additionnal fields", "fields"),
+        'name'           => __("Additional fields", "fields"),
         'version'        => PLUGIN_FIELDS_VERSION,
         'author'         => 'Teclib\', Olivier Moron',
         'homepage'       => 'https://github.com/pluginsGLPI/fields',


### PR DESCRIPTION
This PR is used to correct the spelling of this plugin.
Wasn't sure if I should have created a new issue for this small fix. Sorry, if I was wrong.


Best regards
