### PR TITLE
fix(display): check data after reload from self-service

### DIFF
--- a/ajax/container.php
+++ b/ajax/container.php
@@ -30,30 +30,33 @@
 
 include("../../../inc/includes.php");
 
-if (isset($_GET['action'])) {
-    if ($_GET['action'] === 'get_add_form') {
-        $status_override = new PluginFieldsContainerDisplayCondition();
-        $status_override->showForm(0, $_GET);
-    } else if ($_GET['action'] === 'get_edit_form') {
-        $status_override = new PluginFieldsContainerDisplayCondition();
-        $status_override->getFromDB($_GET['id']);
-        $status_override->showForm($_GET['id'], $_GET);
+use Glpi\Http\Response;
+
+if (isset($_GET['action']) && $_GET['action'] === 'get_fields_html') {
+    $containers_id = $_GET['id'];
+    $itemtype      = $_GET['itemtype'];
+    $items_id      = (int)$_GET['items_id'];
+    $type          = $_GET['type'];
+    $subtype       = $_GET['subtype'];
+    $input         = $_GET['input'];
+
+    $item = new $itemtype();
+    if ($items_id > 0 && !$item->getFromDB($items_id)) {
+        Response::sendError(404, 'Not Found');
     }
-} else if (isset($_POST['action'])) {
-    if ($_POST['action'] === 'get_itemtype_so') {
-        if (isset($_POST['itemtype']) && class_exists($_POST['itemtype'])) {
-            echo PluginFieldsContainerDisplayCondition::showItemtypeFieldForm($_POST['itemtype']) ;
-        } else {
-            echo "";
-        }
-    } else if ($_POST['action'] === 'get_condition_switch_so') {
-        if (isset($_POST['search_option_id']) && (isset($_POST['itemtype']) && class_exists($_POST['itemtype']))) {
-            echo PluginFieldsContainerDisplayCondition::showSearchOptionCondition($_POST['search_option_id'], $_POST['itemtype']);
-        } else {
-            echo "";
-        }
+    $item->input = $input;
+
+    $display_condition = new PluginFieldsContainerDisplayCondition();
+    if ($display_condition->computeDisplayContainer($item, $containers_id)) {
+        PluginFieldsField::showDomContainer(
+            $containers_id,
+            $item,
+            $type,
+            $subtype
+        );
+    } else {
+        echo "";
     }
 } else {
-    http_response_code(400);
-    die();
+    Response::sendError(404, 'Not Found');
 }

--- a/ajax/container_display_condition.php
+++ b/ajax/container_display_condition.php
@@ -38,6 +38,29 @@ if (isset($_GET['action'])) {
         $status_override = new PluginFieldsContainerDisplayCondition();
         $status_override->getFromDB($_GET['id']);
         $status_override->showForm($_GET['id'], $_GET);
+    } else if ($_GET['action'] === 'get_html_fields') {
+        $c_id       = $_GET['c_id'];
+        $itemtype   = $_GET['itemtype'];
+        $items_id   = $_GET['items_id'];
+        $type       = $_GET['type'];
+        $subtype    = $_GET['subtype'];
+        $input      = $_GET['values'];
+
+        $item = new $itemtype();
+        $item->getFromDB($items_id);
+
+        $display_condition = new PluginFieldsContainerDisplayCondition();
+        if ($display_condition->computeDisplayContainer($item, $c_id, $input)) {
+            PluginFieldsField::showDomContainer(
+                $c_id,
+                $itemtype,
+                $items_id,
+                $type,
+                $subtype
+            );
+        } else {
+            echo "";
+        }
     }
 } else if (isset($_POST['action'])) {
     if ($_POST['action'] === 'get_itemtype_so') {

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1273,7 +1273,7 @@ HTML;
                 $value = $data[$name];
             } else if (isset($data['plugin_fields_' . $name . 'dropdowns_id'])) {
                 $value = $data['plugin_fields_' . $name . 'dropdowns_id'];
-            } else if ($field['mandatory'] == 1) {
+            } else if ($field['mandatory'] == 1 && isset($data['items_id'])) {
                 $tablename = getTableForItemType(self::getClassname($itemtype, $container->fields['name']));
 
                 $query = "SELECT * FROM `$tablename` WHERE

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1234,6 +1234,17 @@ HTML;
             'plugin_fields_containers_id' => $data['plugin_fields_containers_id']
         ]);
 
+        // Apply status overrides
+        $status_overrides = $data['status'] !== null
+            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $data['status'])
+            : [];
+        foreach ($status_overrides as $status_override) {
+            if (isset($fields[$status_override['plugin_fields_fields_id']])) {
+                $fields[$status_override['plugin_fields_fields_id']]['is_readonly'] = $status_override['is_readonly'];
+                $fields[$status_override['plugin_fields_fields_id']]['mandatory'] = $status_override['mandatory'];
+            }
+        }
+
         foreach ($fields as $field) {
             if (!$field['is_active']) {
                 continue;
@@ -1519,6 +1530,9 @@ HTML;
            //no ID yet while creating
             $data['items_id'] = $item->getID();
         }
+
+        // Add status so it can be used with status overrides
+        $data['status'] = $item->fields['status'] ?? null;
 
         $has_fields = false;
         foreach ($fields as $field) {

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1235,8 +1235,9 @@ HTML;
         ]);
 
         // Apply status overrides
-        $status_overrides = $data['status'] !== null
-            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $data['status'])
+        $status_field_name = PluginFieldsStatusOverride::getStatusFieldName($itemtype);
+        $status_overrides = $data[$status_field_name] !== null
+            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $data[$status_field_name])
             : [];
         foreach ($status_overrides as $status_override) {
             if (isset($fields[$status_override['plugin_fields_fields_id']])) {
@@ -1532,7 +1533,13 @@ HTML;
         }
 
         // Add status so it can be used with status overrides
-        $data['status'] = $item->fields['status'] ?? null;
+        $status_field_name = PluginFieldsStatusOverride::getStatusFieldName($item->getType());
+        $data[$status_field_name] = null;
+        if (array_key_exists($status_field_name, $item->input) && $item->input[$status_field_name] !== '') {
+            $data[$status_field_name] = (int)$item->input[$status_field_name];
+        } elseif (array_key_exists($status_field_name, $item->fields) && $item->fields[$status_field_name] !== '') {
+            $data[$status_field_name] = (int)$item->fields[$status_field_name];
+        }
 
         $has_fields = false;
         foreach ($fields as $field) {

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1036,7 +1036,7 @@ HTML;
         foreach ($found_c as $data) {
             $dataitemtypes = json_decode($data['itemtypes']);
             if (in_array(get_class($item), $dataitemtypes) != false) {
-                return PluginFieldsField::showForTabContainer($data['id'], $item->fields['id'], get_class($item));
+                return PluginFieldsField::showForTabContainer($data['id'], $item);
             }
         }
     }

--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -402,7 +402,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
         switch ($condition) {
             case self::SHOW_CONDITION_EQ:
                 // '='
-                if ($value ==$object_fields[$searchOption['linkfield']]) {
+                if ($value == $object_fields[$searchOption['linkfield']]) {
                     return false;
                 }
                 break;

--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -392,12 +392,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
         $condition = $this->fields['condition'];
         $searchOption = Search::getOptions(get_class($item))[$this->fields['search_option']];
 
-        //if from self-service form
-        if ($params != null) {
-            $object_fields = $params;
-        } else {
-            $object_fields = $item->fields;
-        }
+        $object_fields = array_merge($item->fields, $params);
 
         switch ($condition) {
             case self::SHOW_CONDITION_EQ:

--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -362,7 +362,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
     }
 
 
-    public function computeDisplayContainer($item, $container_id, $params = null)
+    public function computeDisplayContainer($item, $container_id, $input)
     {
         //load all condition for itemtype and container
         $displayCondition = new self();
@@ -372,7 +372,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
             $display = true;
             foreach ($found_dc as $data) {
                 $displayCondition->getFromDB($data['id']);
-                $result = $displayCondition->checkCondition($item, $params);
+                $result = $displayCondition->checkCondition($item, $input);
                 if (!$result) {
                     return $result;
                 }
@@ -386,13 +386,13 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
     }
 
 
-    public function checkCondition($item, $params = null)
+    public function checkCondition($item, array $input)
     {
         $value = $this->fields['value'];
         $condition = $this->fields['condition'];
         $searchOption = Search::getOptions(get_class($item))[$this->fields['search_option']];
 
-        $object_fields = array_merge($item->fields, $params);
+        $object_fields = array_merge($item->fields, $input);
 
         switch ($condition) {
             case self::SHOW_CONDITION_EQ:

--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -362,7 +362,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
     }
 
 
-    public function computeDisplayContainer($item, $container_id)
+    public function computeDisplayContainer($item, $container_id, $params = null)
     {
         //load all condition for itemtype and container
         $displayCondition = new self();
@@ -372,7 +372,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
             $display = true;
             foreach ($found_dc as $data) {
                 $displayCondition->getFromDB($data['id']);
-                $result = $displayCondition->checkCondition($item);
+                $result = $displayCondition->checkCondition($item, $params);
                 if (!$result) {
                     return $result;
                 }
@@ -386,34 +386,41 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
     }
 
 
-    public function checkCondition($item)
+    public function checkCondition($item, $params = null)
     {
         $value = $this->fields['value'];
         $condition = $this->fields['condition'];
         $searchOption = Search::getOptions(get_class($item))[$this->fields['search_option']];
 
+        //if from self-service form
+        if ($params != null) {
+            $object_fields = $params;
+        } else {
+            $object_fields = $item->fields;
+        }
+
         switch ($condition) {
             case self::SHOW_CONDITION_EQ:
                 // '='
-                if ($value == $item->fields[$searchOption['linkfield']]) {
+                if ($value ==$object_fields[$searchOption['linkfield']]) {
                     return false;
                 }
                 break;
             case self::SHOW_CONDITION_NE:
                 // '≠'
-                if ($value != $item->fields[$searchOption['linkfield']]) {
+                if ($value != $object_fields[$searchOption['linkfield']]) {
                     return false;
                 }
                 break;
             case self::SHOW_CONDITION_LT:
                 // '<';
-                if ($item->fields[$searchOption['linkfield']] > $value) {
+                if ($object_fields[$searchOption['linkfield']] > $value) {
                     return false;
                 }
                 break;
             case self::SHOW_CONDITION_GT:
                 //'>';
-                if ($item->fields[$searchOption['linkfield']] > $value) {
+                if ($object_fields[$searchOption['linkfield']] > $value) {
                     return false;
                 }
                 break;
@@ -421,7 +428,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
                 //'regex';
                 if (self::checkRegex($value)) {
                     $value = Sanitizer::unsanitize($value);
-                    if (preg_match_all($value . "i", $item->fields[$searchOption['linkfield']]) > 0) {
+                    if (preg_match_all($value . "i", $object_fields[$searchOption['linkfield']]) > 0) {
                         return false;
                     }
                 }

--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -362,7 +362,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
     }
 
 
-    public function computeDisplayContainer($item, $container_id, $input)
+    public function computeDisplayContainer($item, $container_id)
     {
         //load all condition for itemtype and container
         $displayCondition = new self();
@@ -372,7 +372,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
             $display = true;
             foreach ($found_dc as $data) {
                 $displayCondition->getFromDB($data['id']);
-                $result = $displayCondition->checkCondition($item, $input);
+                $result = $displayCondition->checkCondition($item);
                 if (!$result) {
                     return $result;
                 }
@@ -386,36 +386,36 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
     }
 
 
-    public function checkCondition($item, array $input)
+    public function checkCondition($item)
     {
         $value = $this->fields['value'];
         $condition = $this->fields['condition'];
         $searchOption = Search::getOptions(get_class($item))[$this->fields['search_option']];
 
-        $object_fields = array_merge($item->fields, $input);
+        $fields = array_merge($item->fields, $item->input);
 
         switch ($condition) {
             case self::SHOW_CONDITION_EQ:
                 // '='
-                if ($value == $object_fields[$searchOption['linkfield']]) {
+                if ($value == $fields[$searchOption['linkfield']]) {
                     return false;
                 }
                 break;
             case self::SHOW_CONDITION_NE:
                 // '≠'
-                if ($value != $object_fields[$searchOption['linkfield']]) {
+                if ($value != $fields[$searchOption['linkfield']]) {
                     return false;
                 }
                 break;
             case self::SHOW_CONDITION_LT:
                 // '<';
-                if ($object_fields[$searchOption['linkfield']] > $value) {
+                if ($fields[$searchOption['linkfield']] > $value) {
                     return false;
                 }
                 break;
             case self::SHOW_CONDITION_GT:
                 //'>';
-                if ($object_fields[$searchOption['linkfield']] > $value) {
+                if ($fields[$searchOption['linkfield']] > $value) {
                     return false;
                 }
                 break;
@@ -423,7 +423,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
                 //'regex';
                 if (self::checkRegex($value)) {
                     $value = Sanitizer::unsanitize($value);
-                    if (preg_match_all($value . "i", $object_fields[$searchOption['linkfield']]) > 0) {
+                    if (preg_match_all($value . "i", $fields[$searchOption['linkfield']]) > 0) {
                         return false;
                     }
                 }

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -795,6 +795,9 @@ JAVASCRIPT
                             input:    data
                         },
                         success: function(data) {
+                            // Close open select2 dropdown that will be replaced
+                            $('#{$html_id}').find('.select2-hidden-accessible').select2('close');
+                            // Refresh fields HTML
                             $('#{$html_id}').html(data);
                         }
                     }
@@ -814,6 +817,7 @@ JAVASCRIPT
                         }
                     );
 
+                    var refresh_timeout = null;
                     form.find('textarea').each(
                         function () {
                             const editor = tinymce.get(this.id);
@@ -824,7 +828,11 @@ JAVASCRIPT
                                         if ($(evt.target.targetElm).closest('#{$html_id}').length > 0) {
                                             return; // Do nothing if element is inside fields container
                                         }
-                                        refreshContainer();
+
+                                        if (refresh_timeout !== null) {
+                                            window.clearTimeout(refresh_timeout);
+                                        }
+                                        refresh_timeout = window.setTimeout(refreshContainer, 1000);
                                     }
                                 );
                             }
@@ -856,7 +864,6 @@ JAVASCRIPT
 
         // Fill status overrides if needed
         if (in_array($item->getType(), PluginFieldsStatusOverride::getStatusItemtypes())) {
-            Toolbox::logDebug($item->fields);
             $status_overrides = PluginFieldsStatusOverride::getOverridesForItem($container_obj->getID(), $item);
             foreach ($status_overrides as $status_override) {
                 if (isset($fields[$status_override['plugin_fields_fields_id']])) {

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -802,12 +802,8 @@ JAVASCRIPT
                     console.log("TINYMCE Change");
                 });
             }, 2000);
-
-
             JAVASCRIPT
         );
-
-
     }
 
     public static function prepareHtmlFields(

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -855,7 +855,8 @@ JAVASCRIPT
         $container_obj->getFromDB($first_field['plugin_fields_containers_id']);
 
         // Fill status overrides if needed
-        if (!$item->isNewItem() && in_array($item->getType(), PluginFieldsStatusOverride::getStatusItemtypes())) {
+        if (in_array($item->getType(), PluginFieldsStatusOverride::getStatusItemtypes())) {
+            Toolbox::logDebug($item->fields);
             $status_overrides = PluginFieldsStatusOverride::getOverridesForItem($container_obj->getID(), $item);
             foreach ($status_overrides as $status_override) {
                 if (isset($fields[$status_override['plugin_fields_fields_id']])) {

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -751,7 +751,7 @@ JAVASCRIPT
         }
 
         $display_condition = new PluginFieldsContainerDisplayCondition();
-        if ($display_condition->computeDisplayContainer($item, $c_id)) {
+        if ($display_condition->computeDisplayContainer($item, $c_id, $params['options'])) {
             self::showDomContainer(
                 $c_id,
                 $item::getType(),

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -780,7 +780,7 @@ JAVASCRIPT
             }
 
             //do not check select DOM -> reload page is triggered on change
-            $('#itil-form').on('keyup change paste', 'input', function(){
+            $('#itil-form').on('keyup change paste', 'input, select', function(){
                 checkContainerVisibility();
             });
             JAVASCRIPT

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -750,13 +750,26 @@ JAVASCRIPT
             return false;
         }
 
+        echo "<div id='fields_container'>";
+        $display_condition = new PluginFieldsContainerDisplayCondition();
+        if ($display_condition->computeDisplayContainer($item, $c_id, $params['options'])) {
+            self::showDomContainer(
+                $c_id,
+                $item::getType(),
+                $item->getID(),
+                $type,
+                $subtype
+            );
+        }
+        echo "</div>";
+
         //JS to trigger any change and check if container need to be display or not
         $ajax_url   = Plugin::getWebDir('fields') . '/ajax/container_display_condition.php';
-        $items_id = $item->getID() ? $item->getID() : 0;
+        $items_id = !$item->isNewItem() ? $item->getID() : 0;
         echo Html::scriptBlock(<<<JAVASCRIPT
 
             function checkContainerVisibility(){
-                var data = $('#itil-form').serializeArray().reduce(function(obj, item) {
+                var data = $('#fields_container').closest('form').serializeArray().reduce(function(obj, item) {
                     obj[item.name] = item.value;
                     return obj;
                 }, {});
@@ -780,24 +793,21 @@ JAVASCRIPT
             }
 
             //do not check select DOM -> reload page is triggered on change
-            $('#itil-form').on('keyup change paste', 'input, select', function(){
+            $('#fields_container').closest('form').on('keyup change paste', 'input, select', function(){
                 checkContainerVisibility();
             });
+
+            setTimeout(function(){
+                tinymce.on('keyup copy change paste', function (e) {
+                    console.log("TINYMCE Change");
+                });
+            }, 2000);
+
+
             JAVASCRIPT
         );
 
-        echo "<div id='fields_container'>";
-        $display_condition = new PluginFieldsContainerDisplayCondition();
-        if ($display_condition->computeDisplayContainer($item, $c_id, $params['options'])) {
-            self::showDomContainer(
-                $c_id,
-                $item::getType(),
-                $item->getID(),
-                $type,
-                $subtype
-            );
-        }
-        echo "</div>";
+
     }
 
     public static function prepareHtmlFields(

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -614,7 +614,7 @@ JAVASCRIPT
         $this->showFormButtons($options);
     }
 
-    public static function showForTabContainer($c_id, $items_id, $itemtype)
+    public static function showForTabContainer($c_id, $item)
     {
         //profile restriction (for reading profile)
         $profile = new PluginFieldsProfile();
@@ -629,10 +629,10 @@ JAVASCRIPT
         $fields = $field_obj->find(['plugin_fields_containers_id' => $c_id, 'is_active' => 1], "ranking");
         echo "<form method='POST' action='" . Plugin::getWebDir('fields') . "/front/container.form.php'>";
         echo Html::hidden('plugin_fields_containers_id', ['value' => $c_id]);
-        echo Html::hidden('items_id', ['value' => $items_id]);
-        echo Html::hidden('itemtype', ['value' => $itemtype]);
+        echo Html::hidden('items_id', ['value' => $item->getID()]);
+        echo Html::hidden('itemtype', ['value' => $item->getType()]);
         echo "<table class='tab_cadre_fixe'>";
-        echo self::prepareHtmlFields($fields, $items_id, $itemtype, $canedit);
+        echo self::prepareHtmlFields($fields, $item, $canedit);
 
         if ($canedit) {
             echo "<tr><td class='tab_bg_2 center' colspan='4'>";
@@ -650,23 +650,22 @@ JAVASCRIPT
     /**
      * Display dom container
      *
-     * @param integer $c_id     Container's ID
-     * @param string  $itemtype Item type
-     * @param integer $items_id Item ID
-     * @param string  $type     Type (either 'dom' or 'domtab'
-     * @param string  $subtype  Requested subtype (used for domtab only)
+     * @param int         $id       Container's ID
+     * @param CommonDBTM  $item     Item
+     * @param string      $type     Type (either 'dom' or 'domtab'
+     * @param string      $subtype  Requested subtype (used for domtab only)
      *
      * @return void
      */
-    public static function showDomContainer($c_id, $itemtype, $items_id, $type = "dom", $subtype = "")
+    public static function showDomContainer($id, $item, $type = "dom", $subtype = "")
     {
 
-        if ($c_id !== false) {
+        if ($id !== false) {
             //get fields for this container
             $field_obj = new self();
             $fields = $field_obj->find(
                 [
-                    'plugin_fields_containers_id' => $c_id,
+                    'plugin_fields_containers_id' => $id,
                     'is_active' => 1,
                 ],
                 "ranking"
@@ -677,7 +676,7 @@ JAVASCRIPT
 
         echo Html::hidden('_plugin_fields_type', ['value' => $type]);
         echo Html::hidden('_plugin_fields_subtype', ['value' => $subtype]);
-        echo self::prepareHtmlFields($fields, $items_id, $itemtype);
+        echo self::prepareHtmlFields($fields, $item);
     }
 
     /**
@@ -690,6 +689,12 @@ JAVASCRIPT
     public static function showForTab($params)
     {
         $item    = $params['item'];
+
+        if (count($item->input) === 0 && count($params['options']) > 0) {
+            // On simplified interface, when form is reloaded (e.g. on category change), existing input is located
+            // `$params['options']` instead of being in `$item->input`.
+            $item->input = $params['options'];
+        }
 
         $functions = array_column(debug_backtrace(), 'function');
 
@@ -750,13 +755,13 @@ JAVASCRIPT
             return false;
         }
 
-        echo "<div id='fields_container'>";
+        $html_id = 'plugin_fields_container_' . mt_rand();
+        echo "<div id='{$html_id}'>";
         $display_condition = new PluginFieldsContainerDisplayCondition();
-        if ($display_condition->computeDisplayContainer($item, $c_id, $params['options'])) {
+        if ($display_condition->computeDisplayContainer($item, $c_id)) {
             self::showDomContainer(
                 $c_id,
-                $item::getType(),
-                $item->getID(),
+                $item,
                 $type,
                 $subtype
             );
@@ -764,52 +769,76 @@ JAVASCRIPT
         echo "</div>";
 
         //JS to trigger any change and check if container need to be display or not
-        $ajax_url   = Plugin::getWebDir('fields') . '/ajax/container_display_condition.php';
+        $ajax_url   = Plugin::getWebDir('fields') . '/ajax/container.php';
         $items_id = !$item->isNewItem() ? $item->getID() : 0;
         echo Html::scriptBlock(<<<JAVASCRIPT
-
-            function checkContainerVisibility(){
-                var data = $('#fields_container').closest('form').serializeArray().reduce(function(obj, item) {
-                    obj[item.name] = item.value;
-                    return obj;
-                }, {});
-
-                $.ajax({
-                    url : '{$ajax_url}',
-                    type : 'GET',
-                    data : {
-                        'action' : 'get_html_fields',
-                        'c_id' : {$c_id},
-                        'itemtype' : '{$item::getType()}',
-                        'items_id' : {$items_id},
-                        'type' : '{$type}',
-                        'subtype' : '{$subtype}',
-                        'values' : data
+            function refreshContainer() {
+                const data = $('#{$html_id}').closest('form').serializeArray().reduce(
+                    function(obj, item) {
+                        obj[item.name] = item.value;
+                        return obj;
                     },
-                    success : function(data) {
-                        $("#fields_container").html(data);
+                    {}
+                );
+
+                $.ajax(
+                    {
+                        url: '{$ajax_url}',
+                        type: 'GET',
+                        data: {
+                            action:   'get_fields_html',
+                            id:       {$c_id},
+                            itemtype: '{$item::getType()}',
+                            items_id: {$items_id},
+                            type:     '{$type}',
+                            subtype:  '{$subtype}',
+                            input:    data
+                        },
+                        success: function(data) {
+                            $('#{$html_id}').html(data);
+                        }
                     }
-                });
+                );
             }
+            $(
+                function () {
+                    const form = $('#{$html_id}').closest('form');
+                    form.on(
+                        'change',
+                        'input, select, textarea',
+                        function(evt) {
+                            if ($(evt.target).closest('#{$html_id}').length > 0) {
+                                return; // Do nothing if element is inside fields container
+                            }
+                            refreshContainer();
+                        }
+                    );
 
-            //do not check select DOM -> reload page is triggered on change
-            $('#fields_container').closest('form').on('keyup change paste', 'input, select', function(){
-                checkContainerVisibility();
-            });
-
-            setTimeout(function(){
-                tinymce.on('keyup copy change paste', function (e) {
-                    console.log("TINYMCE Change");
-                });
-            }, 2000);
-            JAVASCRIPT
+                    form.find('textarea').each(
+                        function () {
+                            const editor = tinymce.get(this.id);
+                            if (editor !== null) {
+                                editor.on(
+                                    'change',
+                                    function(evt) {
+                                        if ($(evt.target.targetElm).closest('#{$html_id}').length > 0) {
+                                            return; // Do nothing if element is inside fields container
+                                        }
+                                        refreshContainer();
+                                    }
+                                );
+                            }
+                        }
+                    );
+                }
+            );
+JAVASCRIPT
         );
     }
 
     public static function prepareHtmlFields(
         $fields,
-        $items_id,
-        $itemtype,
+        $item,
         $canedit = true,
         $show_table = true,
         $massiveaction = false
@@ -826,12 +855,7 @@ JAVASCRIPT
         $container_obj->getFromDB($first_field['plugin_fields_containers_id']);
 
         // Fill status overrides if needed
-        $item = new $itemtype();
-        if (!empty($items_id)) {
-            $item->getFromDB($items_id);
-        }
-
-        if (!$item->isNewItem() && in_array($itemtype, PluginFieldsStatusOverride::getStatusItemtypes())) {
+        if (!$item->isNewItem() && in_array($item->getType(), PluginFieldsStatusOverride::getStatusItemtypes())) {
             $status_overrides = PluginFieldsStatusOverride::getOverridesForItem($container_obj->getID(), $item);
             foreach ($status_overrides as $status_override) {
                 if (isset($fields[$status_override['plugin_fields_fields_id']])) {
@@ -844,12 +868,12 @@ JAVASCRIPT
         $found_v = null;
         if (!$item->isNewItem()) {
             //find row for this object with the items_id
-            $classname = PluginFieldsContainer::getClassname($itemtype, $container_obj->fields['name']);
+            $classname = PluginFieldsContainer::getClassname($item->getType(), $container_obj->fields['name']);
             $obj = new $classname();
             $found_values = $obj->find(
                 [
                     'plugin_fields_containers_id' => $first_field['plugin_fields_containers_id'],
-                    'items_id' => $items_id,
+                    'items_id' => $item->getID(),
                 ]
             );
             $found_v = array_shift($found_values);
@@ -866,16 +890,10 @@ JAVASCRIPT
         $first_found_p = array_shift($found_p);
 
         // test status for "CommonITILObject" objects
-        if (is_subclass_of($itemtype, "CommonITILObject")) {
-            $items_obj = new $itemtype();
-            if ($items_id > 0) {
-                $items_obj->getFromDB($items_id);
-            } else {
-                $items_obj->getEmpty();
-            }
-
+        if ($item instanceof CommonITILObject) {
+            $status = $item->fields['status'] ?? null;
             if (
-                in_array($items_obj->fields['status'], $items_obj->getClosedStatusArray())
+                ($status !== null && in_array($status, $item->getClosedStatusArray()))
                 || $first_found_p['right'] != CREATE
             ) {
                 $canedit = false;
@@ -976,8 +994,6 @@ JAVASCRIPT
             $field['value'] = $value;
         }
 
-        $item = new $itemtype();
-        $item->getFromDB($items_id);
         $html = TemplateRenderer::getInstance()->render('@fields/fields.html.twig', [
             'item'           => $item,
             'fields'         => $fields,
@@ -1031,7 +1047,10 @@ JAVASCRIPT
         ];
 
         //show field
-        echo self::prepareHtmlFields($fields, 0, $itemtype, true, false, $massiveaction);
+        $item = new $itemtype();
+        $itemtype->getEmpty();
+
+        echo self::prepareHtmlFields($fields, $item, true, false, $massiveaction);
 
         return true;
     }

--- a/inc/statusoverride.class.php
+++ b/inc/statusoverride.class.php
@@ -203,7 +203,7 @@ class PluginFieldsStatusOverride extends CommonDBChild
             return [];
         }
         $status_field_name = self::getStatusFieldName($item->getType());
-        $status = $item->fields[$status_field_name];
+        $status = $item->input[$status_field_name] ?? $item->fields[$status_field_name] ?? null;
         $overrides = self::getOverridesForContainer($container_id);
         $itemtype = $item->getType();
         $overrides = array_filter($overrides, static function ($override) use ($itemtype, $status) {

--- a/inc/statusoverride.class.php
+++ b/inc/statusoverride.class.php
@@ -203,7 +203,13 @@ class PluginFieldsStatusOverride extends CommonDBChild
         }
 
         $status_field_name = self::getStatusFieldName($item->getType());
-        $status = $item->input[$status_field_name] ?? $item->fields[$status_field_name] ?? null;
+        $status = null;
+        if (array_key_exists($status_field_name, $item->input) && $item->input[$status_field_name] !== '') {
+            $status = (int)$item->input[$status_field_name];
+        } elseif (array_key_exists($status_field_name, $item->fields) && $item->fields[$status_field_name] !== '') {
+            $status = (int)$item->fields[$status_field_name];
+        }
+
         return $status !== null
            ? self::getOverridesForItemtypeAndStatus($container_id, $item->getType(), $status)
            : [];

--- a/inc/statusoverride.class.php
+++ b/inc/statusoverride.class.php
@@ -198,18 +198,27 @@ class PluginFieldsStatusOverride extends CommonDBChild
 
     public static function getOverridesForItem(int $container_id, CommonDBTM $item): array
     {
-        $status_itemtypes = self::getStatusItemtypes();
-        if (!in_array($item->getType(), $status_itemtypes)) {
+        if (!in_array($item::getType(), self::getStatusItemtypes(), true)) {
             return [];
         }
+
         $status_field_name = self::getStatusFieldName($item->getType());
         $status = $item->input[$status_field_name] ?? $item->fields[$status_field_name] ?? null;
+        return $status !== null
+           ? self::getOverridesForItemtypeAndStatus($container_id, $item->getType(), $status)
+           : [];
+    }
+
+    public static function getOverridesForItemtypeAndStatus(int $container_id, string $itemtype, int $status): array
+    {
+        if (!in_array($itemtype, self::getStatusItemtypes(), true)) {
+            return [];
+        }
+
         $overrides = self::getOverridesForContainer($container_id);
-        $itemtype = $item->getType();
-        $overrides = array_filter($overrides, static function ($override) use ($itemtype, $status) {
-            return $override['itemtype'] === $itemtype && in_array($status, $override['states']);
+        return array_filter($overrides, static function ($override) use ($itemtype, $status) {
+            return $override['itemtype'] === $itemtype && in_array($status, $override['states'], false);
         });
-        return $overrides;
     }
 
     private static function getItemtypesForContainer(int $container_id): array

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -43,7 +43,7 @@
     {% set type     = field['type'] %}
     {% set name     = field['name'] %}
     {% set label    = field['label'] %}
-    {% set value    = field['value'] %}
+    {% set value    = item.input[name] ?: field['value'] %}
     {% set readonly = field['is_readonly'] %}
     {% set rand = random() %}
 


### PR DESCRIPTION
When self-service select an itil categorie from tick

form is reload and fields don't take care of new value

Only work for itilcategories_id because thatt trigger a reload of form

Fix : (portal) !6633
