### PR TITLE
Fix entity restriction in dropdown

### DIFF
--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -100,11 +100,13 @@
 
     {% elseif type matches '/^dropdown-.+/i' %}
         {% if not massiveaction %}
-            {{ macros.dropdownField(field['dropdown_class'], name, value, label, field_options|merge({
-                'entity': field['model_class'] == 'User' ? -1 : item.getEntityID(),
-                'right': 'all',
-                'condition': field['dropdown_condition']
-            })) }}
+            {% set dropdown_options = {'condition': field['dropdown_condition'], 'entity': item.getEntityID()} %}
+            {% if field['dropdown_class'] == 'User' %}
+                {% set dropdown_options = dropdown_options|merge({'entity': -1, 'right': 'all'}) %}
+            {% elseif field['dropdown_class'] == 'Entity' %}
+                {% set dropdown_options = dropdown_options|merge({'entity_sons': true}) %}
+            {% endif %}
+            {{ macros.dropdownField(field['dropdown_class'], name, value, label, field_options|merge(dropdown_options)) }}
         {% endif %}
 
     {% elseif type == 'glpi_item' %}


### PR DESCRIPTION
fixes #547

1. the wrong variable was evaluated
2. `right: 'all'` should be defined only for `User` dropdown
3. add a `entity_sons: true` to Entity dropdowns

For Entity dropdown, using `entity_sons` seems mandatory, otherwise only one value would be proposed. On other fields, maybe we should add a `recursive` boolean to dropdown in order to giv ability to administrator to define the value to pass to `entity_sons`.