### PR TITLE
Do not output HTML in command line install

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -60,12 +60,16 @@ function plugin_fields_install()
     ];
 
     $migration = new Migration($version);
-    echo "<center>";
-    echo "<table class='tab_cadre_fixe'>";
-    echo "<tr><th>" . __("MySQL tables installation", "fields") . "<th></tr>";
+    if (isCommandLine()) {
+        echo __("MySQL tables installation", "fields") . "\n";
+    } else {
+        echo "<center>";
+        echo "<table class='tab_cadre_fixe'>";
+        echo "<tr><th>" . __("MySQL tables installation", "fields") . "<th></tr>";
 
-    echo "<tr class='tab_bg_1'>";
-    echo "<td align='center'>";
+        echo "<tr class='tab_bg_1'>";
+        echo "<td align='center'>";
+    }
 
     //load all classes
     $dir  = PLUGINFIELDS_DIR . "/inc/";
@@ -93,10 +97,11 @@ function plugin_fields_install()
 
     $migration->executeMigration();
 
-    echo "</td>";
-    echo "</tr>";
-    echo "</table></center>";
-
+    if (!isCommandLine()) {
+        echo "</td>";
+        echo "</tr>";
+        echo "</table></center>";
+    }
     return true;
 }
 


### PR DESCRIPTION
Avoid outputting HTML when running the plugin install though `bin/console` :

```
Traitement du plugin « fields »...
<center><table class='tab_cadre_fixe'><tr><th>Installation des tables MySQL<th></tr><tr class='tab_bg_1'><td align='center'></td></tr></table></center>Le plugin « fields » a été installé et peut être activé.
Traitement du plugin « fields »...
Le plugin « fields » a été activé.
```
