### PR TITLE
Fixed field names to fix searchOptions to permit dropdown-Itemtype in same Itemtype container

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -264,7 +264,14 @@ class PluginFieldsField extends CommonDBChild
             $input['name'] = $toolbox->getSystemNameFromLabel($input['label']) . 'field';
         }
 
-        //for dropdown, if already exist, link to it
+        // for dropdowns like dropdown-User, dropdown-Computer, etc...
+        $re = "/^dropdown-(?<type>.+)$/";
+        $match = [];
+        if (preg_match($re, $input['type'], $match) === 1) {
+           $input['name'] = getForeignKeyFieldForItemType($match['type']) . "_" . $input['name'];
+        }
+
+        //for dropdown, if already exists, link to it
         if (isset($input['type']) && $input['type'] === "dropdown") {
             $found = $this->find(['name' => $input['name']]);
             if (!empty($found)) {
@@ -282,6 +289,15 @@ class PluginFieldsField extends CommonDBChild
         while (count($field->find(['name' => $field_name])) > 0) {
             $field_name = $toolbox->getIncrementedSystemName($input['name'], $i);
             $i++;
+        }
+
+        // if it's too long then use a random postfix
+        // MySQL/MariaDB official limit for a column name is 64 chars,
+        // but there is a bug when trying to drop the column and the real max len is 53 chars
+        // FIXME: see: https://bugs.mysql.com/bug.php?id=107165
+        if (strlen($field_name) > 52) {
+           $rand = rand();
+           $field_name = substr($field_name, 0, 52 - strlen($rand)) . $rand;
         }
 
         return $field_name;
@@ -513,24 +529,12 @@ class PluginFieldsField extends CommonDBChild
 JAVASCRIPT
             );
 
-            // Exclude dropdown that corresponds to itemtypes targetted by container.
-            // This will prevent issues with search options.
-            // FIXME: Fix search options handling and remove this limitation.
-            $itemtypes_to_exclude = !empty($container->fields['itemtypes'])
-                ? array_map(
-                    function ($itemtype) {
-                        return 'dropdown-' . $itemtype;
-                    },
-                    json_decode($container->fields['itemtypes'])
-                )
-                : [];
             Dropdown::showFromArray(
                 'type',
                 self::getTypes(false),
                 [
                     'value'     => $this->fields['type'],
                     'on_change' => 'plugin_fields_change_field_type_' . $rand . '(this.value)',
-                    'used'      => array_combine($itemtypes_to_exclude, $itemtypes_to_exclude),
                 ]
             );
         }

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -268,7 +268,7 @@ class PluginFieldsField extends CommonDBChild
         $re = "/^dropdown-(?<type>.+)$/";
         $match = [];
         if (preg_match($re, $input['type'], $match) === 1) {
-           $input['name'] = getForeignKeyFieldForItemType($match['type']) . "_" . $input['name'];
+            $input['name'] = getForeignKeyFieldForItemType($match['type']) . "_" . $input['name'];
         }
 
         //for dropdown, if already exists, link to it
@@ -296,8 +296,8 @@ class PluginFieldsField extends CommonDBChild
         // but there is a bug when trying to drop the column and the real max len is 53 chars
         // FIXME: see: https://bugs.mysql.com/bug.php?id=107165
         if (strlen($field_name) > 52) {
-           $rand = rand();
-           $field_name = substr($field_name, 0, 52 - strlen($rand)) . $rand;
+            $rand = rand();
+            $field_name = substr($field_name, 0, 52 - strlen($rand)) . $rand;
         }
 
         return $field_name;

--- a/plugin.xml
+++ b/plugin.xml
@@ -95,6 +95,7 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
       <author>François Legastelois</author>
       <author>Walid Nouh</author>
       <author>Johan Cwiklinski</author>
+      <author>Olivier Moron</author>
    </authors>
    <versions>
       <version>


### PR DESCRIPTION
Hello,

1. Fixed bug that prevented to add a dropdown field of the itemtype than the container (ex: dropdown-User in a User container)
1. Added a length limit to field names: Official length limit is 64 chars for column names, but there is a bug in MySQL which prevents drop of column with a length(name) >= 53.
1. Added myself to author list

Thank you,
Regards,
Tomolimo