### PR TITLE
Fix tinymce

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -692,6 +692,8 @@ JAVASCRIPT
      */
     public static function showForTab($params)
     {
+        Html::requireJs('tinymce');
+
         $item = $params['item'];
 
         $functions = array_column(debug_backtrace(), 'function');


### PR DESCRIPTION
Seems to be an issue introduced by https://github.com/pluginsGLPI/fields/commit/3dc14345532dcc561528df28fff6c9e7ee8fa15a

I've got some js failure on the computer page:
![image](https://user-images.githubusercontent.com/42734840/194879840-9284459e-068e-44ef-bb37-0c04fb1a77d5.png)

I've forced loaded tinymce in the relevant function, not sure if it is the best way to fix this.