### PR TITLE
Added Sockets to item types

### DIFF
--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -222,6 +222,7 @@ class PluginFieldsToolbox
             PDU::class,
             PassiveDCEquipment::class,
             Cable::class,
+            Glpi\Socket::class,
         ];
 
         $assistance_itemtypes = [


### PR DESCRIPTION
Base additional fields plugin is missing the ability to add fields to Socket items (formerly network outlet). 
Adding a class reference for Sockets into the getGlpiItemtypes function allows new fields to be added through the plugin.

![image](https://user-images.githubusercontent.com/61054231/204859893-80a1df75-fc41-4899-9389-9768dea72682.png)
