### PR TITLE
fix: url link was altered

### DIFF
--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -65,7 +65,7 @@
     {% elseif type == 'url' %}
             {% set ext_link %}
             {% if value|length %}
-                <a target="_blank" href="{{ value }}">
+                <a target="_blank" href="{{ value|raw }}">
                     <i class="ti ti-external-link"></i>
                     {{ __('show', 'fields') }}
                 </a>

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -65,7 +65,7 @@
     {% elseif type == 'url' %}
             {% set ext_link %}
             {% if value|length %}
-                <a target="_blank" href="{{ value|raw }}">
+                <a target="_blank" href="{{ value|verbatim_value }}">
                     <i class="ti ti-external-link"></i>
                     {{ __('show', 'fields') }}
                 </a>


### PR DESCRIPTION
On a field of type URL, in the link "show" was modified: `&` was replaced by `&#38;` so the link was not valid

![image](https://user-images.githubusercontent.com/8530352/207599949-55720336-4bf7-4202-9bdc-6f5f4c319492.png)

ref !25927