### PR TITLE
fix(core): fix found value on refresh

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -909,14 +909,15 @@ class PluginFieldsField extends CommonDBChild
                         'change',
                         'input, select, textarea',
                         function(evt) {
-                            //Do not refresh tab container when form is reload
-                            //prevent twice call and NULL field value after refresh
-                            if (evt.target.name != "itilcategories_id") {
-                                if ($(evt.target).closest('#{$html_id}').length > 0) {
-                                    return; // Do nothing if element is inside fields container
-                                }
-                                refreshContainer();
+                            if (evt.target.name == "itilcategories_id") {
+                                // Do not refresh tab container when form is reloaded
+                                // to prevent issues diues to duplicated calls
+                                return;
                             }
+                            if ($(evt.target).closest('#{$html_id}').length > 0) {
+                                return; // Do nothing if element is inside fields container
+                            }
+                            refreshContainer();
                         }
                     );
 
@@ -1071,25 +1072,18 @@ JAVASCRIPT
 
             if (!$field['is_readonly']) {
                 if ($field['type'] == "dropdown") {
-                    if (
-                        isset($_SESSION['plugin']['fields']['values_sent']["plugin_fields_" .
-                                                                     $field['name'] .
-                                                                     "dropdowns_id"])
-                    ) {
-                        $value = $_SESSION['plugin']['fields']['values_sent']["plugin_fields_" .
-                                                                        $field['name'] .
-                                                                        "dropdowns_id"];
-                    } else {
-                        //find from $item->input du to ajax refresh container
-                        if (isset($item->input["plugin_fields_" . $field['name'] . "dropdowns_id"])) {
-                            $value = $item->input["plugin_fields_" . $field['name'] . "dropdowns_id"];
-                        }
+                    $field_name = sprintf('plugin_fields_%sdropdowns_id', $field['name']);
+                    if (isset($_SESSION['plugin']['fields']['values_sent'][$field_name])) {
+                        $value = $_SESSION['plugin']['fields']['values_sent'][$field_name];
+                    } elseif (isset($item->input[$field_name])) {
+                        // find from $item->input due to ajax refresh container
+                        $value = $item->input[$field_name];
                     }
                 } else {
                     if (isset($_SESSION['plugin']['fields']['values_sent'][$field['name']])) {
                         $value = $_SESSION['plugin']['fields']['values_sent'][$field['name']];
                     } elseif (isset($item->input[$field['name']])) {
-                        //find from $item->input du to ajax refresh container
+                        // find from $item->input due to ajax refresh container
                         $value = $item->input[$field['name']];
                     }
                 }

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -909,10 +909,14 @@ class PluginFieldsField extends CommonDBChild
                         'change',
                         'input, select, textarea',
                         function(evt) {
-                            if ($(evt.target).closest('#{$html_id}').length > 0) {
-                                return; // Do nothing if element is inside fields container
+                            //Do not refresh tab container when form is reload
+                            //prevent twice call and NULL field value after refresh
+                            if (evt.target.name != "itilcategories_id") {
+                                if ($(evt.target).closest('#{$html_id}').length > 0) {
+                                    return; // Do nothing if element is inside fields container
+                                }
+                                refreshContainer();
                             }
-                            refreshContainer();
                         }
                     );
 
@@ -1075,9 +1079,19 @@ JAVASCRIPT
                         $value = $_SESSION['plugin']['fields']['values_sent']["plugin_fields_" .
                                                                         $field['name'] .
                                                                         "dropdowns_id"];
+                    } else {
+                        //find from $item->input du to ajax refresh container
+                        if (isset($item->input["plugin_fields_" . $field['name'] . "dropdowns_id"])) {
+                            $value = $item->input["plugin_fields_" . $field['name'] . "dropdowns_id"];
+                        }
                     }
-                } else if (isset($_SESSION['plugin']['fields']['values_sent'][$field['name']])) {
-                    $value = $_SESSION['plugin']['fields']['values_sent'][$field['name']];
+                } else {
+                    if (isset($_SESSION['plugin']['fields']['values_sent'][$field['name']])) {
+                        $value = $_SESSION['plugin']['fields']['values_sent'][$field['name']];
+                    } elseif (isset($item->input[$field['name']])) {
+                        //find from $item->input du to ajax refresh container
+                        $value = $item->input[$field['name']];
+                    }
                 }
             }
 


### PR DESCRIPTION
Do not refresh tab container when form is reload (when ```itilcategories_id``` change)
to prevent twice call 
The first one ( ```itilcategories_id``` change) get right value but unset it from ```$_SESSION``` 
The second call (caused by reload page) return ```NULL```

When field refresh container (to check visibility) data are not set in ```$_SESSION```  but in ```$item->input```
TRy to find value from ```$_SESSION``` first then in ```$item->input```

Internal ref = !26275