### PR TITLE
Fix yes/no default value

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -1096,7 +1096,7 @@ JAVASCRIPT
 
             //get default value
             if ($value === null) {
-                if ($field['type'] === 'dropdown' && $field['default_value'] === '') {
+                if (in_array($field['type'], ['dropdown', 'yesno']) && $field['default_value'] === '') {
                     $value = 0;
                 } else if ($field['default_value'] !== "") {
                     $value = $field['default_value'];


### PR DESCRIPTION
For yesno field default value must be 0

If default value is not set and readonly is active that create an sql error :

Error: Incorrect integer value: '' for column 'fieldname' at row 1