### PR TITLE
prevent unwanted duplicate fields name changes

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -68,9 +68,6 @@ class PluginFieldsDropdown
             }
         }
 
-        $toolbox = new PluginFieldsToolbox();
-        $toolbox->fixFieldsNames($migration, ['type' => 'dropdown']);
-
         // Ensure data is update before regenerating files.
         $migration->executeMigration();
 

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -122,9 +122,6 @@ class PluginFieldsField extends CommonDBChild
         // change default_value from varchar to longtext
         $migration->changeField($table, 'default_value', 'default_value', 'longtext');
 
-        $toolbox = new PluginFieldsToolbox();
-        $toolbox->fixFieldsNames($migration, ['NOT' => ['type' => 'dropdown']]);
-
         //move old types to new format
         $migration->addPostQuery(
             $DB->buildUpdate(


### PR DESCRIPTION
When we have more than one identical fields (duplicate)

Fields handle this use case by adding an incremental string at end ```two```, ```free``` etc ....

When adding a new fields it's work perfectly but on plugin update it becomes more complicated to check whether one field is a duplicate of another

Let's take an example of two ```valise``` fields managed by the plugin in this way

```sql
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+
| id | name                  | label         | type | plugin_fields_containers_id | ranking | default_value | is_active | is_readonly | mandatory | multiple | allowed_values |
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+
| 10 | valisefield           | valise        | text |                           1 |       1 |               |         1 |           0 |         0 |        0 | NULL           |
| 11 | valisefieldtwo        | valise        | text |                           1 |       2 |               |         1 |           0 |         0 |        0 | NULL           |
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+

```

if the plugin is updated, it becomes like this ```valisefieldtwo``` =>   ```valisefieldthree``` 

```sql
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+
| id | name                  | label         | type | plugin_fields_containers_id | ranking | default_value | is_active | is_readonly | mandatory | multiple | allowed_values |
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+
| 10 | valisefield           | valise        | text |                           1 |       1 |               |         1 |           0 |         0 |        0 | NULL           |
| 11 | valisefieldthree      | valise        | text |                           1 |       2 |               |         1 |           0 |         0 |        0 | NULL           |
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+
```

if the plugin is updated again , it becomes like this ```valisefieldthree``` =>   ```valisefieldtwo``` 

```sql
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+
| id | name                  | label         | type | plugin_fields_containers_id | ranking | default_value | is_active | is_readonly | mandatory | multiple | allowed_values |
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+
| 10 | valisefield           | valise        | text |                           1 |       1 |               |         1 |           0 |         0 |        0 | NULL           |
| 11 | valisefieldtwo        | valise        | text |                           1 |       2 |               |         1 |           0 |         0 |        0 | NULL           |
+----+-----------------------+---------------+------+-----------------------------+---------+---------------+-----------+-------------+-----------+----------+----------------+

```

```fields``` try to compute internal name by label and check if is the same as in database

When manage  ```valisefieldtwo``` with label ```valise```  it return ```valisefield``` which is different, so it renames the field

```php

public function fixFieldsNames(Migration $migration, $condition)
{
    global $DB;

    $bad_named_fields = [];
    $fields = $DB->request(
        [
            'FROM' => PluginFieldsField::getTable(),
            'WHERE' => $condition,
        ]
    );
    foreach ($fields as $field) {
        $field_copy = $field;
        unset($field_copy['name']);
        if ($field['name'] !== (new PluginFieldsField())->prepareName($field_copy, false)) { //HERE COMPUTED NAME IS DIFFERENT FROM STORED NAME
            $bad_named_fields[] = $field;
        }
    }

    if (count($bad_named_fields) === 0) {
        return;
    }

    $migration->displayMessage(__("Fix fields names", "fields"));

    foreach ($bad_named_fields as $field) {
        $old_name = $field['name'];

        // Update field name
        $field['name'] = null;
        $field_obj = new PluginFieldsField();
        $new_name = $field_obj->prepareName($field);
        if ($new_name > 64) {
            // limit fields names to 64 chars (MySQL limit)
            $new_name = substr($new_name, 0, 64);
        }
        while (
            'dropdown' === $field['type']
            && strlen(getTableForItemType(PluginFieldsDropdown::getClassname($new_name))) > 64
        ) {
            // limit tables names to 64 chars (MySQL limit)
            $new_name = substr($new_name, 0, -1);
        }

        ........
        ........
        ........
    }
}
```


from the ```prepareName``` function, it is possible to prevent duplications 

If we enable this check, it's the ```Migration``` class that deletes the column because of this

```Migration.php, function changeField L510)```

```php

        if ($DB->fieldExists($table, $oldfield, false)) {
           // in order the function to be replayed
           // Drop new field if name changed
            if (
                ($oldfield != $newfield)
                && $DB->fieldExists($table, $newfield)
            ) {
                $this->change[$table][] = "DROP `$newfield` ";
            }

            if ($format) {
                $this->change[$table][] = "CHANGE `$oldfield` `$newfield` $format " . $params['comment'] . " " .
                                      $params['null'] . $params['first'] . $params['after'];
            }
            return true;
        }
``` 

My suggestion is simply to remove the check on names, as this has already been done when a field is added, so there doesn't seem to be need when the plugin is updated.

NB: only applies in the case of a duplicate field other than of ```Dropdown``` type (```Dropdown``` type does not allow adding a field with same name)




