### PR TITLE
Fix issue with wrong default value for container

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1532,7 +1532,7 @@ HTML;
 
         $container = new PluginFieldsContainer();
         $itemtypes = $container->find($condition);
-        $id = 0;
+        $id = false; // default value when no container matches criterion
         if (count($itemtypes) < 1) {
             return false;
         }


### PR DESCRIPTION
Default value for $id must be false, otherwise the searches for container in preItem() will failed.