### PR TITLE
Fix error when no fields are updated

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1320,6 +1320,7 @@ HTML;
             // -- update existing item --
 
             // construct $updates
+            $updates = [];
             if ($field_obj->updates) {
                 foreach ($field_obj->updates as $key) {
                     $updates[$key] = [0, $field_obj->oldvalues[$key], $field_obj->input[$key]];


### PR DESCRIPTION
Fixes following errors:

```
[2023-09-14 10:50:57] glpiphplog.WARNING: *** PHP Warning (2): Undefined variable $updates in C:\inetpub\wwwroot\marketplace\fields\inc\container.class.php at line 1330
Backtrace :
marketplace\fields\inc\container.class.php:1195 PluginFieldsContainer::constructHistory()
marketplace\fields\inc\container.class.php:1595 PluginFieldsContainer->updateFieldsValues()
src\Plugin.php:1475 PluginFieldsContainer::preItemUpdate()
src\CommonDBTM.php:1591 Plugin::doHook()
front\ticket.form.php:84 CommonDBTM->update()

[2023-09-14 10:50:57] glpiphplog.WARNING: *** PHP Warning (2): foreach() argument must be of type array|object, null given in C:\inetpub\wwwroot\marketplace\fields\inc\container.class.php at line 1330
Backtrace :
marketplace\fields\inc\container.class.php:1195 PluginFieldsContainer::constructHistory()
marketplace\fields\inc\container.class.php:1595 PluginFieldsContainer->updateFieldsValues()
src\Plugin.php:1475 PluginFieldsContainer::preItemUpdate()
src\CommonDBTM.php:1591 Plugin::doHook()
front\ticket.form.php:84 CommonDBTM->update()
```