### PR TITLE
fix: empty multiple-dropdown field

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1168,6 +1168,8 @@ HTML;
             }
             if (array_key_exists($field_name, $data)) {
                 $data[$field_name] = json_encode($data[$field_name]);
+            } elseif (array_key_exists('_' . $field_name . '_defined', $data)) {
+                $data[$field_name] = json_encode([]);
             }
         }
 


### PR DESCRIPTION
Values could be modified, but not emptied

ref: !29677