### PR TITLE
fix: backslash in input text

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -99,7 +99,7 @@ function plugin_init_fields()
         ) {
             foreach ($_POST as $key => $value) {
                 if (!is_array($value)) {
-                    $_SESSION['plugin']['fields']['values_sent'][$key] = stripcslashes($value);
+                    $_SESSION['plugin']['fields']['values_sent'][$key] = $value;
                 }
             }
         }


### PR DESCRIPTION
For example, when a text input was added to a ticket and `\` were entered, these were interpreted when the ticket was reloaded by the save action, but not when the ticket was simply loaded.

Original value:
![image](https://github.com/pluginsGLPI/fields/assets/8530352/d92b3457-d74f-4587-8190-97187dfeb002)

Before fix:
![image](https://github.com/pluginsGLPI/fields/assets/8530352/be45140f-b389-47e6-8024-5a12fd629820)
