### PR TITLE
Fix(Container): deactivate domtab that no longer works and stop offer…

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -898,11 +898,17 @@ HTML;
     public static function showFormItemtype($params = [])
     {
         $is_domtab = isset($params['type']) && $params['type'] == 'domtab';
+        $values = self::getItemtypes($is_domtab);
+
+        //remove ITISolution from values if type is tab
+        if (!isset($params['type']) || (isset($params['type']) && $params['type'] == 'tab')) {
+            unset($values[__('Assistance')]['ITILSolution']);
+        }
 
         $rand = $params['rand'];
         Dropdown::showFromArray(
             "itemtypes",
-            self::getItemtypes($is_domtab),
+            $values,
             [
                 'rand'                => $rand,
                 'multiple'            => !$is_domtab,

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -323,8 +323,9 @@ class PluginFieldsContainer extends CommonDBTM
             }
         }
 
-        //Ticket Solution tab no longer exist move to ITILSolution dom
-        //Problem Solution tab no longer exist move to ITILSolution dom
+
+        //Ticket Solution tab no longer exist exist disable it
+        //Problem Solution tab no longer exist exist disable it
         //Change Analysis / Solution / Plans no longer exist disable it
         $DB->update(
             'glpi_plugin_fields_containers',

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -324,8 +324,8 @@ class PluginFieldsContainer extends CommonDBTM
         }
 
 
-        //Ticket Solution tab no longer exist exist disable it
-        //Problem Solution tab no longer exist exist disable it
+        //Ticket Solution tab no longer exist disable it
+        //Problem Solution tab no longer exist disable it
         //Change Analysis / Solution / Plans no longer exist disable it
         $DB->update(
             'glpi_plugin_fields_containers',

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -323,6 +323,26 @@ class PluginFieldsContainer extends CommonDBTM
             }
         }
 
+        //Ticket Solution tab no longer exist move to ITILSolution dom
+        //Problem Solution tab no longer exist move to ITILSolution dom
+        //Change Analysis / Solution / Plans no longer exist disable it
+        $DB->update(
+            'glpi_plugin_fields_containers',
+            [
+                'is_active' => 0,
+            ],
+            [
+                'type' => 'domtab',
+                [
+                    'OR' => [
+                        ['subtype' => ['LIKE', 'Ticket$2']],
+                        ['subtype' => ['LIKE', 'Problem$2']],
+                        ['subtype' => ['LIKE', 'Change$%']],
+                    ],
+                ],
+            ]
+        );
+
         // Ensure data is update before regenerating files.
         $migration->executeMigration();
 
@@ -1984,19 +2004,6 @@ HTML;
     {
         $tabs = [];
         switch ($item::getType()) {
-            case Ticket::getType():
-            case Problem::getType():
-                $tabs = [
-                    $item::getType() . '$2' => __('Solution')
-                ];
-                break;
-            case Change::getType():
-                $tabs = [
-                    'Change$1' => __('Analysis'),
-                    'Change$2' => __('Solution'),
-                    'Change$3' => __('Plans')
-                ];
-                break;
             case Entity::getType():
                 $tabs = [
                     'Entity$2' => __('Address'),

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -863,12 +863,12 @@ class PluginFieldsField extends CommonDBChild
         $item = $params['item'];
 
         $functions = array_column(debug_backtrace(), 'function');
-
         $subtype = isset($_SESSION['glpi_tabs'][strtolower($item::getType())]) ? $_SESSION['glpi_tabs'][strtolower($item::getType())] : "";
         $type = substr($subtype, -strlen('$main')) === '$main'
             || in_array('showForm', $functions)
             || in_array('showPrimaryForm', $functions)
             || in_array('showFormHelpdesk', $functions)
+            || $item::getType() == ITILSolution::class
                 ? 'dom'
                 : 'domtab';
         if ($subtype == -1) {
@@ -917,6 +917,7 @@ class PluginFieldsField extends CommonDBChild
             strpos($current_url, ".form.php") === false
             && strpos($current_url, ".injector.php") === false
             && strpos($current_url, ".public.php") === false
+            && strpos($current_url, "ajax/timeline.php") === false // ITILSolution load from timeline
         ) {
             return false;
         }
@@ -1044,6 +1045,7 @@ class PluginFieldsField extends CommonDBChild
 JAVASCRIPT
         );
     }
+
 
     public static function prepareHtmlFields(
         $fields,

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -236,6 +236,7 @@ class PluginFieldsToolbox
             Ticket::class,
             Problem::class,
             Change::class,
+            ITILSolution::class,
             TicketRecurrent::class,
             RecurrentChange::class,
             PlanningExternalEvent::class,


### PR DESCRIPTION
Since GLPI 10

```Ticket``` ```Solution``` tab no longer exist
```Problem``` ```Solution``` tab no longer exist
```Change``` ```Analysis``` / ```Solution``` / ```Plans``` no longer exist

So, deactivate related ```container``` (with type ```Insertion in the form of a specific tab (before save button)```) and remove the ability to create containers on these tabs (tabs on ```Entity``` are maintained as they are still functional))


**Release note should mention this :**

Adding a container (with type ```Insertion in the form of a specific tab (before save button)```) to the following tabs is no longer possible (as it no longer works since version 10)
- Change -> analysis
- Change -> plans
- Change -> solution
- Ticket -> solution
- Problem -> solution

All related container have been deactivated

For the ```Solution```, it is now possible to add a block on ITILSolution, only for the "Insertion in the form (before save button)" type.

**IMPORTANT**
no migration proposed from the old type to the new one, 
as it hasn't worked for a while, I don't suppose anyone has added a block 
and required lot of work

 
Fix : 
https://github.com/pluginsGLPI/fields/issues/737
https://github.com/pluginsGLPI/fields/issues/407 
https://github.com/pluginsGLPI/fields/issues/599 
https://github.com/pluginsGLPI/fields/issues/456
