### PR TITLE
Fix(Overrides): load overrides from related item if container is 'tab' type

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1412,21 +1412,19 @@ HTML;
             'plugin_fields_containers_id' => $data['plugin_fields_containers_id']
         ]);
 
-        // Apply status overrides
-        $status_field_name = PluginFieldsStatusOverride::getStatusFieldName($itemtype);
-        $status_overrides = array_key_exists($status_field_name, $data) && $data[$status_field_name] !== null
-            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $data[$status_field_name])
-            : [];
 
-        // If no overrides are loaded, it may be because by the container if it's type is 'tab'
-        // this implies that it does not contain the fields of the parent object in $data
-        // try to load overrides with related item fields instead of $data
+        $status_value = null;
         $relatedItem = new $data['itemtype']();
-        if (empty($status_overrides) && $relatedItem->getFromDB($data['items_id'])) {
-            $status_overrides = array_key_exists($status_field_name, $relatedItem->fields) && $relatedItem->fields[$status_field_name] !== null
-            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $relatedItem->fields[$status_field_name])
-            : [];
+        $status_field_name = PluginFieldsStatusOverride::getStatusFieldName($itemtype);
+        if ($container->fields['type'] === 'dom') {
+            $status_value = $data[$status_field_name] ?? null;
+        } else {
+            $status_value = $relatedItem->fields[$status_field_name] ?? null;
         }
+        // Apply status overrides
+        $status_overrides = $status_value !== null
+            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $status_value)
+            : [];
 
         foreach ($status_overrides as $status_override) {
             if (isset($fields[$status_override['plugin_fields_fields_id']])) {

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1417,6 +1417,17 @@ HTML;
         $status_overrides = array_key_exists($status_field_name, $data) && $data[$status_field_name] !== null
             ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $data[$status_field_name])
             : [];
+
+        // If no overrides are loaded, it may be because by the container if it's type is 'tab'
+        // this implies that it does not contain the fields of the parent object in $data
+        // try to load overrides with related item fields instead of $data
+        $relatedItem = new $data['itemtype']();
+        if (empty($status_overrides) && $relatedItem->getFromDB($data['items_id'])) {
+            $status_overrides = array_key_exists($status_field_name, $relatedItem->fields) && $relatedItem->fields[$status_field_name] !== null
+            ? PluginFieldsStatusOverride::getOverridesForItemtypeAndStatus($container->getID(), $itemtype, $relatedItem->fields[$status_field_name])
+            : [];
+        }
+
         foreach ($status_overrides as $status_override) {
             if (isset($fields[$status_override['plugin_fields_fields_id']])) {
                 $fields[$status_override['plugin_fields_fields_id']]['is_readonly'] = $status_override['is_readonly'];

--- a/templates/status_overrides.html.twig
+++ b/templates/status_overrides.html.twig
@@ -31,6 +31,18 @@
 
 <div id="container{{ rand }}" class="asset {{ bg }}">
 
+   <div class='alert alert-primary d-flex align-items-center' role='alert'>
+      <i class='fas fa-info-circle fa-xl'></i>
+      <span class='ms-2'>
+         {{ __("Here you can redefine the following options :") }}
+         <ul>
+            <li><i> {{__("Mandatory") }} </i></li>
+            <li><i>{{ __("Read-only") }} </i></li>
+         </ul>
+         {{ __("for each field, depending on the states of the element attached to the container.") }}
+      </span>
+   </div>
+
    {% if has_fields %}
       <div class="d-flex align-items-start mb-3">
          <button class="btn btn-primary me-2"


### PR DESCRIPTION
Container with 'tab' type can load override 

it does not contain the fields of the parent object in $data

This PR fix this by loading overrides with related item fields instead of $data

Fix : https://github.com/pluginsGLPI/fields/issues/739

Add explanatory text

![image](https://github.com/pluginsGLPI/fields/assets/7335054/44bd37d1-5f3b-491b-bcbd-59c22f07dcb5)


Fix : https://github.com/pluginsGLPI/fields/issues/738
