### PR TITLE
fix(SearchOption): Fix search on multiple dropdown

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -338,6 +338,7 @@ function plugin_datainjection_populate_fields()
 
 function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
 {
+    /** @var \DBmysql $DB */
     global $DB;
 
     $searchopt = &Search::getOptions($itemtype);

--- a/hook.php
+++ b/hook.php
@@ -359,7 +359,6 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
     ) {
         return $link . $DB->quoteName("$table" . "_" . "$field") . "." .  $DB->quoteName($field) . "LIKE " . $DB->quoteValue("%\"$val\"%") ;
     } else {
-
         // if 'multiple' field with cleaned name is found -> 'dropdown' case
         // update WHERE clause with LIKE statement
         $cleanfield = str_replace("plugin_fields_", "", $field);

--- a/hook.php
+++ b/hook.php
@@ -346,7 +346,8 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
     $field     = $searchopt[$ID]["field"];
 
     $field_field = new PluginFieldsField();
-    // if 'multiple' field with name is found
+
+    // if 'multiple' field with name is found -> 'Dropdown-XXXX' case
     // update WHERE clause with LIKE statement
     if (
         $field_field->getFromDBByCrit(
@@ -356,7 +357,24 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
             ]
         )
     ) {
-        ;
         return $link . $DB->quoteName("$table" . "_" . "$field") . "." .  $DB->quoteName($field) . "LIKE " . $DB->quoteValue("%\"$val\"%") ;
+    } else {
+
+        // if 'multiple' field with cleaned name is found -> 'dropdown' case
+        // update WHERE clause with LIKE statement
+        $cleanfield = str_replace("plugin_fields_", "", $field);
+        $cleanfield = str_replace("dropdowns_id", "", $cleanfield);
+        if (
+            $field_field->getFromDBByCrit(
+                [
+                    'name' => $cleanfield,
+                    'multiple' => true
+                ]
+            )
+        ) {
+            return $link . $DB->quoteName("$table" . "_" . "$cleanfield") . "." .  $DB->quoteName($field) . "LIKE " . $DB->quoteValue("%\"$val\"%") ;
+        } else {
+            return false;
+        }
     }
 }

--- a/hook.php
+++ b/hook.php
@@ -338,6 +338,8 @@ function plugin_datainjection_populate_fields()
 
 function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
 {
+    global $DB;
+
     $searchopt = &Search::getOptions($itemtype);
     $table     = $searchopt[$ID]["table"];
     $field     = $searchopt[$ID]["field"];
@@ -353,6 +355,7 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
             ]
         )
     ) {
-        return $link . " `$table" . "_" . "$field`" . "." . "`$field` LIKE '%\"$val\"%'";
+        ;
+        return $link . $DB->quoteName("$table" . "_" . "$field") . "." .  $DB->quoteName($field) . "LIKE " . $DB->quoteValue("%\"$val\"%") ;
     }
 }

--- a/hook.php
+++ b/hook.php
@@ -353,6 +353,6 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
             ]
         )
     ) {
-        return $link . " `$table" . "_" . "$field`" . "." . "`$field` LIKE '%$val%'";
+        return $link . " `$table" . "_" . "$field`" . "." . "`$field` LIKE '%\"$val\"%'";
     }
 }

--- a/hook.php
+++ b/hook.php
@@ -335,3 +335,24 @@ function plugin_datainjection_populate_fields()
         }
     }
 }
+
+function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
+{
+    $searchopt = &Search::getOptions($itemtype);
+    $table     = $searchopt[$ID]["table"];
+    $field     = $searchopt[$ID]["field"];
+
+    $field_field = new PluginFieldsField();
+    // if 'multiple' field with name is found
+    // update WHERE clause with LIKE statement
+    if (
+        $field_field->getFromDBByCrit(
+            [
+                'name' => $field,
+                'multiple' => true
+            ]
+        )
+    ) {
+        return $link . " `$table" . "_" . "$field`" . "." . "`$field` LIKE '%$val%'";
+    }
+}

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -50,7 +50,11 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
                 if (!is_a($itemtype, CommonDBTM::class, true)) {
                     return ''; // Itemtype not exists (maybe a deactivated plugin)
                 }
-                return Dropdown::show($itemtype, ['name' => $name, 'display' => false]);
+                $display_with = [];
+                if ($itemtype == User::class) {
+                    $display_with = ['lastname', 'firstname'];
+                }
+                return Dropdown::show($itemtype, ['displaywith' => $display_with, 'name' => $name, 'display' => false]);
             }
         }
         return parent::getSpecificValueToSelect($field, $name, $values, $options);

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -52,7 +52,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
                 }
                 $display_with = [];
                 if ($itemtype == User::class) {
-                    $display_with = ['lastname', 'firstname'];
+                    $display_with = ['realname', 'firstname'];
                 }
                 return Dropdown::show($itemtype, ['displaywith' => $display_with, 'name' => $name, 'display' => false]);
             } else if (

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -30,6 +30,33 @@
 
 abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 {
+    public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
+    {
+
+        if (!is_array($values)) {
+            $values = [$field => $values];
+        }
+
+        $field_id = $options['searchopt']['pfields_fields_id'] ?? null;
+
+        $field_specs = new PluginFieldsField();
+        if ($field_id !== null && $field_specs->getFromDB($field_id)) {
+            $dropdown_matches = [];
+            if (
+                preg_match('/^dropdown-(?<class>.+)$/i', $field_specs->fields['type'], $dropdown_matches) === 1
+                && $field_specs->fields['multiple']
+            ) {
+                $itemtype = $dropdown_matches['class'];
+                if (!is_a($itemtype, CommonDBTM::class, true)) {
+                    return ''; // Itemtype not exists (maybe a deactivated plugin)
+                }
+                return Dropdown::show($itemtype, ['name' => $name, 'display' => false]);
+            }
+        }
+        return parent::getSpecificValueToSelect($field, $name, $values, $options);
+    }
+
+
     public static function getSpecificValueToDisplay($field, $values, array $options = [])
     {
         if (!is_array($values)) {

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -55,6 +55,12 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
                     $display_with = ['lastname', 'firstname'];
                 }
                 return Dropdown::show($itemtype, ['displaywith' => $display_with, 'name' => $name, 'display' => false]);
+            } else if (
+                $field_specs->fields['type'] === 'dropdown'
+                && $field_specs->fields['multiple']
+            ) {
+                $itemtype = PluginFieldsDropdown::getClassname($field_specs->fields['name']);
+                return Dropdown::show($itemtype, ['name' => $name, 'display' => false]);
             }
         }
         return parent::getSpecificValueToSelect($field, $name, $values, $options);

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1910,6 +1910,7 @@ HTML;
                 if ($data['multiple']) {
                     $opt[$i]['table']      = $tablename;
                     $opt[$i]['field']      = $field_name;
+                    $opt[$i]['searchtype']   = ['equals', 'notequals'];
                     $opt[$i]['datatype']   = 'specific';
                 } else {
                     $opt[$i]['table']      = 'glpi_plugin_fields_' . $data['field_name'] . 'dropdowns';

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1929,6 +1929,7 @@ HTML;
             ) {
                 if ($data['multiple']) {
                     $opt[$i]['datatype']   = 'specific';
+                    $opt[$i]['searchtype']   = ['equals', 'notequals'];
                 } else {
                     $opt[$i]['table']      = CommonDBTM::getTable($dropdown_matches['class']);
                     $opt[$i]['field']      = 'name';


### PR DESCRIPTION
Fix search on multiple dropdown

Actually, ```multiple dropdown``` only use ```contain``` / ```not contain``` ```searchtype```.

SQL query is computed with ```=``` on column that contain ```['ID', 'ID, 'ID']``` and try to match ```string```

Use of ```plugin_fields_addWhere``` to replace ```=``` by ```like``` when related field is from plugin ```fields``` and when it's ```multiple```

Use of ```getSpecificValueToSelect``` to display a ```real``` dropdown.

Force ```'equals', 'notequals'``` ```searchtype```

Fix : internal ref 31426