### PR TITLE
Fix(core): load plugin from CLI

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -86,7 +86,7 @@ function plugin_init_fields()
     $pluginfields_autoloader = new PluginFieldsAutoloader([PLUGINFIELDS_CLASS_PATH]);
     $pluginfields_autoloader->register();
 
-    if ((Session::getLoginUserID() || isCommandLine())&& Plugin::isPluginActive('fields')) {
+    if ((Session::getLoginUserID() || isCommandLine()) && Plugin::isPluginActive('fields')) {
         // Init hook about itemtype(s) for plugin fields
         if (!isset($PLUGIN_HOOKS['plugin_fields'])) {
             $PLUGIN_HOOKS['plugin_fields'] = [];

--- a/setup.php
+++ b/setup.php
@@ -86,7 +86,7 @@ function plugin_init_fields()
     $pluginfields_autoloader = new PluginFieldsAutoloader([PLUGINFIELDS_CLASS_PATH]);
     $pluginfields_autoloader->register();
 
-    if (Session::getLoginUserID() && Plugin::isPluginActive('fields')) {
+    if ((Session::getLoginUserID() || isCommandLine())&& Plugin::isPluginActive('fields')) {
         // Init hook about itemtype(s) for plugin fields
         if (!isset($PLUGIN_HOOKS['plugin_fields'])) {
             $PLUGIN_HOOKS['plugin_fields'] = [];


### PR DESCRIPTION
```load``` / ```enable``` plugin from CLI

should fix : https://github.com/glpi-project/glpi-inventory-plugin/issues/492

```SearchOption``` errors from ```fields``` when a ```CLI``` task executes a command using the fields
