### PR TITLE
fix dropdown recursion

### DIFF
--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -103,6 +103,9 @@
         {% if field['multiple'] %}
             {% set dropdown_options = dropdown_options|merge({'multiple': true}) %}
         {% endif %}
+        {% if item.isRecursive() %}
+            {% set dropdown_options = dropdown_options|merge({'entity_sons': true}) %}
+        {% endif %}
         {% if "dropdowns_id" in name %}
             {% set dropdown_itemtype = call("getItemtypeForForeignKeyField", [name]) %}
         {% else %}
@@ -116,7 +119,7 @@
             {% set dropdown_options = {'condition': field['dropdown_condition'], 'entity': item.getEntityID()} %}
             {% if field['dropdown_class'] == 'User' %}
                 {% set dropdown_options = dropdown_options|merge({'entity': -1, 'right': 'all'}) %}
-            {% elseif field['dropdown_class'] == 'Entity' %}
+            {% elseif field['dropdown_class'] == 'Entity' or item.isRecursive() %}
                 {% set dropdown_options = dropdown_options|merge({'entity_sons': true}) %}
             {% endif %}
             {% if field['multiple'] %}


### PR DESCRIPTION
When the item is on a recursive entity, the dropdown added by fields didn't propose any values in the child entities.

Example: a network port, where Fields adds a port field (to link this port to another). Although the port is recursive, the dropdown did not list the ports of the child entities.

ref !31937