### PR TITLE
Fix list of allowed Search Option

### DIFF
--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -373,7 +373,7 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
                     $main_table == getTableForItemType($itemtype_class)
                 ) {
                     foreach ($foreignKey as $foreign_class) {
-                        if (!is_array($foreign_class) &&  getTableNameForForeignKeyField($foreign_class) != getTableForItemType(Location::getType())) {
+                        if (!is_array($foreign_class) && getTableNameForForeignKeyField($foreign_class) != getTableForItemType(Location::getType())) {
                             $allowed_table[] = getTableForItemType(getItemtypeForForeignKeyField($foreign_class));
                         }
                     }

--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -367,14 +367,17 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
         }
 
         //use relation.constant.php to allow some tables (exclude Location which is managed using `CommonDBTM::maybeLocated()`)
+        $relations = getDbRelations();
         foreach (getDbRelations() as $relation) {
             foreach ($relation as $main_table => $foreignKey) {
                 if (
                     $main_table == getTableForItemType($itemtype_class)
-                    && !is_array($foreignKey)
-                    && getTableNameForForeignKeyField($foreignKey) != getTableForItemType(Location::getType())
                 ) {
-                    $allowed_table[] = getTableNameForForeignKeyField($foreignKey);
+                    foreach ($foreignKey as $foreign_class) {
+                        if (!is_array($foreign_class) &&  getTableNameForForeignKeyField($foreign_class) != getTableForItemType(Location::getType())) {
+                            $allowed_table[] = getTableForItemType(getItemtypeForForeignKeyField($foreign_class));
+                        }
+                    }
                 }
             }
         }

--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -367,7 +367,6 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
         }
 
         //use relation.constant.php to allow some tables (exclude Location which is managed using `CommonDBTM::maybeLocated()`)
-        $relations = getDbRelations();
         foreach (getDbRelations() as $relation) {
             foreach ($relation as $main_table => $foreignKey) {
                 if (


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32319

The list of fields available for adding conditions to plugins fields was incomplete.

Many fields linked to an item were not displayed in the list (e.g. ApplianceType for Appliances).

This fix adds them.
![image](https://github.com/pluginsGLPI/fields/assets/107540223/7a814c42-0ffc-4ffa-bfb3-554e5a595cfe)
