### PR TITLE
fix: Prevent error when classname is null

### DIFF
--- a/templates/injection.class.tpl
+++ b/templates/injection.class.tpl
@@ -2,77 +2,86 @@
 
 class %%CLASSNAME%%Injection extends %%CLASSNAME%% implements PluginDatainjectionInjectionInterface
 {
-   static $rightname = 'plugin_datainjection_model';
+    static $rightname = 'plugin_datainjection_model';
 
-   /**
-    * Return the table used to stor this object
-    *
-    * @see CommonDBTM::getTable()
-    *
-    * @return string
-   **/
-   static function getTable($classname = null) {
-      return getTableForItemType(get_parent_class($classname));
-   }
+    /**
+     * Return the table used to stor this object
+     *
+     * @see CommonDBTM::getTable()
+     *
+     * @return string
+    **/
+    static function getTable($classname = null) {
+        if ($classname === null) {
+            return '';
+        }
+        $parent_class = get_parent_class($classname);
 
-   static function getTypeName($nb = 0) {
-      return %%ITEMTYPE%%::getTypeName() . " - %%CONTAINER_NAME%%";
-   }
+        if ($parent_class === false) {
+            return '';
+        }
 
-   /**
-    * Tells datainjection is the type is a primary type or not
-    *
-    * @return iboolean
-   **/
-   function isPrimaryType() {
-      return false;
-   }
+        return getTableForItemType($parent_class);
+    }
 
-   /**
-    * Indicates to with other types it can be connected
-    *
-    * @return an array of GLPI types
-   **/
-   function connectedTo() {
-      return array('%%ITEMTYPE%%');
-   }
+    static function getTypeName($nb = 0) {
+        return %%ITEMTYPE%%::getTypeName() . " - %%CONTAINER_NAME%%";
+    }
 
-   /**
-    * Function which calls getSearchOptions and add more parameters specific to display
-    *
-    * @param string $primary_type (default '')
-    *
-    * @return array of search options, as defined in each commondbtm object
-   **/
-   function getOptions($primary_type='') {
-      $searchoptions = PluginFieldsContainer::getAddSearchOptions('%%ITEMTYPE%%', %%CONTAINER_ID%%);
+    /**
+     * Tells datainjection is the type is a primary type or not
+     *
+     * @return iboolean
+    **/
+    function isPrimaryType() {
+        return false;
+    }
 
-      foreach ($searchoptions as $id => $data) {
-         $searchoptions[$id]['injectable'] = PluginDatainjectionCommonInjectionLib::FIELD_INJECTABLE;
-         if (!isset($searchoptions[$id]['displaytype'])) {
-            if (isset($searchoptions[$id]['datatype'])) {
-               $searchoptions[$id]['displaytype'] = $searchoptions[$id]['datatype'];
-            } else {
-               $searchoptions[$id]['displaytype'] = 'text';
+    /**
+     * Indicates to with other types it can be connected
+     *
+     * @return an array of GLPI types
+    **/
+    function connectedTo() {
+        return array('%%ITEMTYPE%%');
+    }
+
+    /**
+     * Function which calls getSearchOptions and add more parameters specific to display
+     *
+     * @param string $primary_type (default '')
+     *
+     * @return array of search options, as defined in each commondbtm object
+    **/
+    function getOptions($primary_type='') {
+        $searchoptions = PluginFieldsContainer::getAddSearchOptions('%%ITEMTYPE%%', %%CONTAINER_ID%%);
+
+        foreach ($searchoptions as $id => $data) {
+            $searchoptions[$id]['injectable'] = PluginDatainjectionCommonInjectionLib::FIELD_INJECTABLE;
+            if (!isset($searchoptions[$id]['displaytype'])) {
+                if (isset($searchoptions[$id]['datatype'])) {
+                    $searchoptions[$id]['displaytype'] = $searchoptions[$id]['datatype'];
+                } else {
+                    $searchoptions[$id]['displaytype'] = 'text';
+                }
             }
-         }
-      }
+        }
 
-      return $searchoptions;
-   }
+        return $searchoptions;
+    }
 
-   /**
-    * Standard method to add an object into glpi
-    *
-    * @param $values    array fields to add into glpi
-    * @param $options   array options used during creation
-    *
-    * @return array of IDs of newly created objects:
-    * for example array(Computer=>1, Networkport=>10)
-   **/
-   function addOrUpdateObject($values=array(), $options=array()) {
-      $lib = new PluginDatainjectionCommonInjectionLib($this, $values, $options);
-      $lib->processAddOrUpdate();
-      return $lib->getInjectionResults();
-   }
+    /**
+     * Standard method to add an object into glpi
+     *
+     * @param $values    array fields to add into glpi
+     * @param $options   array options used during creation
+     *
+     * @return array of IDs of newly created objects:
+     * for example array(Computer=>1, Networkport=>10)
+    **/
+    function addOrUpdateObject($values=array(), $options=array()) {
+        $lib = new PluginDatainjectionCommonInjectionLib($this, $values, $options);
+        $lib->processAddOrUpdate();
+        return $lib->getInjectionResults();
+    }
 }


### PR DESCRIPTION
Prevent this error message:

```
glpiphplog.CRITICAL:   *** Uncaught Exception TypeError: get_parent_class(): Argument #1 ($object_or_class) must be an object or a valid class name, null given in /var/www/glpi/files/_plugins/fields/inc/computerchampsadditionnelordinateurinjection.class.php at line 15
  Backtrace :
  ...ampsadditionnelordinateurinjection.class.php:15 get_parent_class()
  ...e/datainjection/inc/injectiontype.class.php:147 PluginFieldsComputerchampsadditionnelordinateurInjection::getTable()
  ...etplace/datainjection/inc/mapping.class.php:145 PluginDatainjectionInjectionType::dropdownLinkedTypes()
  marketplace/datainjection/inc/model.class.php:843  PluginDatainjectionMapping::showFormMappings()
  src/CommonGLPI.php:694                             PluginDatainjectionModel::displayTabContentForItem()
  ajax/common.tabs.php:120                           CommonGLPI::displayStandardTab()
  public/index.php:82                                require()

```