### PR TITLE
(fix) Strpslashes log error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.21.10] - 2024-06-11
+## [unrelease] -
+
+### Fixed
+
+- Fix strpslashes log error (#802)
 
 ### Fixed
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1319,6 +1319,7 @@ HTML;
 
             foreach ($data as $key => $value) {
                 //log only not empty values
+                //do not log if value is empty or if dom name is part of file upload
                 if (!empty($value) && strpos($key, '_uploader_') === false) {
                     //prepare log
                     $changes = [0, "N/A", $value];

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1319,7 +1319,7 @@ HTML;
 
             foreach ($data as $key => $value) {
                 //log only not empty values
-                if (!empty($value)) {
+                if (!empty($value) && strpos($key, '_uploader_') === false) {
                     //prepare log
                     $changes = [0, "N/A", $value];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33520

When filling in a RichText field for the first time, an error appears on the screen.
![image](https://github.com/pluginsGLPI/fields/assets/107540223/133d1854-014f-4e55-a501-ec7562a6488f)

This is due to the attempt to save data in the _updater_... parameter, which is an array, causing the error.
![image](https://github.com/pluginsGLPI/fields/assets/107540223/78607ec1-28b7-4239-9f85-8fa9cf2cd768)
