### PR TITLE
Fix mandatory dropdown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fix generic object bloc fields mandatory
+- Fix handling of empty mandatory fields in generic objects.
 
 ## [1.21.11] - 2024-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrelease] -
 
+### Fixed
+
+- Fix generic object bloc fields mandatory
+
 ## [1.21.11] - 2024-07-10
 
 ### Fixed

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1488,24 +1488,6 @@ HTML;
                 $value = $data[$name];
             } elseif (isset($data['plugin_fields_' . $name . 'dropdowns_id'])) {
                 $value = $data['plugin_fields_' . $name . 'dropdowns_id'];
-            } elseif ($field['mandatory'] == 1 && isset($data['items_id'])) {
-                $tablename = getTableForItemType(self::getClassname($itemtype, $container->fields['name']));
-
-                $iterator = $DB->request([
-                    'FROM' => $tablename,
-                    'WHERE' => [
-                        'itemtype' => $itemtype,
-                        'items_id' => $data['items_id'],
-                        'plugin_fields_containers_id' => $data['plugin_fields_containers_id'],
-                    ],
-                ]);
-
-                $db_result = $iterator->current();
-                if (isset($db_result['plugin_fields_' . $name . 'dropdowns_id'])) {
-                    $value = $db_result['plugin_fields_' . $name . 'dropdowns_id'];
-                } elseif (isset($db_result[$name])) {
-                    $value = $db_result[$name];
-                }
             } else {
                 if ($massiveaction) {
                     continue;
@@ -1837,10 +1819,10 @@ HTML;
                         //values are defined by user
                         if (isset($item->input[$field['name']])) {
                             $data[$field['name']] = $item->input[$field['name']];
+                            $has_fields = true;
                         } else { //multi dropdown is empty or has been emptied
                             $data[$field['name']] = [];
                         }
-                        $has_fields = true;
                     }
                 }
             }


### PR DESCRIPTION
Related ticket : 33594

Plugins : **Generic Objects** X **Fields**

For a generic `Car` object, for example, if you add multiple mandatory fields pointing to GLPI objects (Dropdowns Groups, Users, etc.), object creation fails with an error indicating that mandatory fields are empty.

![image](https://github.com/user-attachments/assets/72972143-9c6f-4a15-a5cf-51e6cd2b3081)
![image](https://github.com/user-attachments/assets/933240c1-a6f1-400a-bac1-77eeafc3976f)

What's more, once this problem had been resolved, it was possible to enter empty values in mandatory fields, because in some cases, if the field in question was not detected in the code (in the case of an empty value) the value was retrieved from the database to check that a mandatory field was indeed non-empty. This meant that an empty value could only be entered in a mandatory field once (which is already too often).

![image](https://github.com/user-attachments/assets/34455cfc-cd09-4818-b93c-f34a25b13bd4)
