### PR TITLE
Fix(Core): fix bulk update for dropdown used in more than one container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix handling of empty mandatory fields in generic objects.
+- Fix massive update for dropdown (shared by several containers)
 
 ## [1.21.11] - 2024-07-10
 

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -1260,16 +1260,12 @@ JAVASCRIPT
                     'FKEY' => [
                         'containers' => 'id',
                         'fields' => 'plugin_fields_containers_id',
-                        [
-                            'AND' => [
-                                'containers.itemtypes' => ['LIKE' => "%$itemtype%"]
-                            ]
-                        ]
                     ]
                 ]
             ],
             'WHERE' => [
-                'fields.name' => $cleaned_linkfield
+                'fields.name' => $cleaned_linkfield,
+                'containers.itemtypes' => ['LIKE', "%$itemtype%"]
             ],
         ]);
 


### PR DESCRIPTION
In fields, a dropdown field can be reused in several containers

However, when several containers use this type of field, it is no longer possible to modify it using mass actions.

The format of the query before the change resulted in an `IN` clause which returned both containers (KO), now we have a `LIKE` clause (which returns a single container (OK)).

