### PR TITLE
Fix field Tab Display label

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1139,7 +1139,7 @@ HTML;
         if (isset($itemtypes[$item->getType()])) {
             $tabs_entries = [];
             $container    = new self();
-            foreach ($itemtypes[$item->getType()] as $tab_name) {
+            foreach ($itemtypes[$item->getType()] as $tab_name => $tab_label) {
                 // needs to check if entity of item is in hierachy of $tab_name
                 foreach ($container->find(['is_active' => 1, 'name' => $tab_name]) as $data) {
                     $dataitemtypes = json_decode($data['itemtypes']);

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1139,7 +1139,7 @@ HTML;
         if (isset($itemtypes[$item->getType()])) {
             $tabs_entries = [];
             $container    = new self();
-            foreach ($itemtypes[$item->getType()] as $tab_name => $tab_label) {
+            foreach ($itemtypes[$item->getType()] as $tab_name) {
                 // needs to check if entity of item is in hierachy of $tab_name
                 foreach ($container->find(['is_active' => 1, 'name' => $tab_name]) as $data) {
                     $dataitemtypes = json_decode($data['itemtypes']);
@@ -1152,7 +1152,7 @@ HTML;
                         if (!$item->isEntityAssign() || in_array($item->fields['entities_id'], $entities)) {
                             $display_condition = new PluginFieldsContainerDisplayCondition();
                             if ($display_condition->computeDisplayContainer($item, $data['id'])) {
-                                $tabs_entries[$tab_name] = $tab_label;
+                                $tabs_entries[$tab_name] = $data['label'];
                             }
                         }
                     }

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -512,7 +512,7 @@ class PluginFieldsField extends CommonDBChild
         if (!$withtemplate) {
             switch ($item->getType()) {
                 case __CLASS__:
-                    $ong[1] = "Test";
+                    $ong[1] = $this->getTypeName(1);
 
                     return $ong;
             }

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -512,7 +512,7 @@ class PluginFieldsField extends CommonDBChild
         if (!$withtemplate) {
             switch ($item->getType()) {
                 case __CLASS__:
-                    $ong[1] = $this->getTypeName(1);
+                    $ong[1] = "Test";
 
                     return $ong;
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !34825
- Here is a brief description of what this PR does

You can define the tag/label of a field in the fields plugin, but when it is modified it is not updated on the pages and keeps the first name that was defined for it.

## Screenshots (if appropriate):

