### PR TITLE
fix: datatype number for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELAESE]
 
 ### Fixed
+- Change the decimal type of number fields to display the decimal part of the decimal numbers in search options.
 - Do not destroy the dropdown table/class if it is being used by another container.
 - Fix fields updates with multiple containers via the API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELAESE]
 
 ### Fixed
-- Change the decimal type of number fields to display the decimal part of the decimal numbers in search options.
+- Force decimal ‘datatype’ of `numeric` fields  for more accurate display.
 - Do not destroy the dropdown table/class if it is being used by another container.
 - Fix fields updates with multiple containers via the API.
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1957,6 +1957,8 @@ HTML;
                     $opt[$i]['datatype'] = 'text';
                     break;
                 case 'number':
+                    $opt[$i]['datatype'] = 'decimal';
+                    break;
                 case 'date':
                 case 'datetime':
                     $opt[$i]['datatype'] = $data['type'];


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.

## Description

- It fixes !35167
- Change the decimal type of number fields to display the decimal part of the decimal numbers in search options

## Screenshots (if appropriate):
![Capture d’écran du 2024-11-18 14-11-57](https://github.com/user-attachments/assets/923b2a11-b6a1-4a39-9386-4e8dbb750a4e)


