### PR TITLE
Fix(Core): Add entities_id and is_recursive fields to correctly filter data from the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELAESE]
+
+### Fixed
+
+- Fix `container` to prevent calls from `API` returning full container data
+
 ## [1.21.15] - 2024-10-09
 
 ### Fixed

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -49,7 +49,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBChild
      *
      * Modification of this function to meet specific requirements.
      */
-    public function addNeededInfoToInput($input)
+    public function addNeededInfoToInput(array $input): array
     {
         if ($this->tryEntityForwarding()) {
             $completeinput = array_merge($this->fields, $input);

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -57,7 +57,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBChild
                 $itemToGetEntity = static::getItemFromArray(
                     static::$itemtype,
                     static::$items_id,
-                    $completeinput
+                    $completeinput,
                 )
             ) {
                 if (

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -33,6 +33,8 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBChild
     public static $itemtype = 'itemtype';
     public static $items_id = 'items_id';
 
+    public static $mustBeAttached     = false;
+
     /**
      * This function relies on the static property `static::$plugins_forward_entity`,
      * which should be populated using the following method (from setup):

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -49,7 +49,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBChild
      *
      * Modification of this function to meet specific requirements.
      */
-    public function addNeededInfoToInput(array $input): array
+    public function addNeededInfoToInput($input)
     {
         if ($this->tryEntityForwarding()) {
             $completeinput = array_merge($this->fields, $input);

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -31,11 +31,6 @@
 abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 {
 
-    public static $undisclosedFields = [];
-
-    public static $itemtype        = 'itemtype';
-    public static $items_id        = 'items_id';
-
     /**
      * Checks if the HTTP request targets an object with an ID.
      *

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -28,14 +28,13 @@
  * -------------------------------------------------------------------------
  */
 
-abstract class PluginFieldsAbstractContainerInstance extends CommonDBChild
+abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 {
 
     public static $undisclosedFields = [];
 
     public static $itemtype        = 'itemtype';
     public static $items_id        = 'items_id';
-
 
     /**
      * Checks if the HTTP request targets an object with an ID.
@@ -64,6 +63,35 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBChild
         return parent::canView();
     }
 
+    public function canViewItem()
+    {
+        //check if current user have access to the main item entity
+        $item = new $this->fields['itemtype']();
+        $item->getFromDB($this->fields['items_id']);
+        if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
+            return false;
+        }
+        $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);
+        if ($right < READ) {
+            return false;
+        }
+        return true;
+    }
+
+    public function canUpdateItem()
+    {
+        //check if current user have access to the main item entity
+        $item = new $this->fields['itemtype']();
+        $item->getFromDB($this->fields['items_id']);
+        if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
+            return false;
+        }
+        $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);
+        if ($right > READ) {
+            return true;
+        }
+        return false;
+    }
     public function canPurgeItem()
     {
         return false;

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -34,7 +34,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
     {
         //check if current user have access to the main item entity
         $item = new $this->fields['itemtype']();
-        $item->getFromDB($this->fields['item_id']);
+        $item->getFromDB($this->fields['items_id']);
         if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
             return false;
         }
@@ -50,7 +50,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
     {
         //check if current user have access to the main item entity
         $item = new $this->fields['itemtype']();
-        $item->getFromDB($this->fields['item_id']);
+        $item->getFromDB($this->fields['items_id']);
         if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
             return false;
         }
@@ -64,10 +64,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 
     public function canPurgeItem()
     {
-        if (isAPI()) {
-            return false;
-        }
-        return true;
+        return false;
     }
 
 

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -30,6 +30,26 @@
 
 abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 {
+
+    public function canViewItem()
+    {
+        $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);
+        if ($right < READ) {
+            return false;
+        }
+        return true;
+    }
+
+    public function canUpdateItem()
+    {
+        $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);
+        if ($right > READ) {
+            return true;
+        }
+        return false;
+    }
+
+
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {
         if (!is_array($values)) {

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -32,6 +32,13 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 {
     public function canViewItem()
     {
+        //check if current user have access to the main item entity
+        $item = new $this->fields['itemtype']();
+        $item->getFromDB($this->fields['item_id']);
+        if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
+            return false;
+        }
+
         $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);
         if ($right < READ) {
             return false;
@@ -41,12 +48,28 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 
     public function canUpdateItem()
     {
+        //check if current user have access to the main item entity
+        $item = new $this->fields['itemtype']();
+        $item->getFromDB($this->fields['item_id']);
+        if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
+            return false;
+        }
+
         $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);
         if ($right > READ) {
             return true;
         }
         return false;
     }
+
+    public function canPurgeItem()
+    {
+        if (isAPI()) {
+            return false;
+        }
+        return true;
+    }
+
 
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -30,7 +30,6 @@
 
 abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 {
-
     public function canViewItem()
     {
         $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);
@@ -48,7 +47,6 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
         }
         return false;
     }
-
 
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
     {

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -31,39 +31,12 @@
 abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
 {
 
-    /**
-     * Checks if the HTTP request targets an object with an ID.
-     *
-     * This function determines whether the path contains an ID as the last segment
-     * (i.e., a number after the final '/').
-     *
-     * @param string $path The HTTP request path (e.g., $_SERVER['PATH_INFO']).
-     * @return mixed Returns ID if is present in the path, null otherwise.
-     */
-    public static function hasRequestedObjectId(string $path): ?int
-    {
-        if (preg_match('#/(\d+)$#', $path, $matches)) {
-            return (int)$matches[1];
-        }
-        return null;
-    }
-
-    public static function canView()
-    {
-        $want_all =  self::hasRequestedObjectId($_SERVER['PATH_INFO']);
-        if (isAPI() && ($want_all == null)) {
-            return false;
-        }
-
-        return parent::canView();
-    }
-
     public function canViewItem()
     {
         //check if current user have access to the main item entity
         $item = new $this->fields['itemtype']();
         $item->getFromDB($this->fields['items_id']);
-        if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
+        if ($item->isEntityAssign() && !Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
             return false;
         }
         $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);
@@ -78,7 +51,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
         //check if current user have access to the main item entity
         $item = new $this->fields['itemtype']();
         $item->getFromDB($this->fields['items_id']);
-        if (!Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
+        if ($item->isEntityAssign() && !Session::haveAccessToEntity($item->getEntityID(), $item->isRecursive())) {
             return false;
         }
         $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $this->fields['plugin_fields_containers_id']);

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -87,6 +87,7 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBTM
         }
         return false;
     }
+
     public function canPurgeItem()
     {
         return false;

--- a/setup.php
+++ b/setup.php
@@ -126,8 +126,7 @@ function plugin_init_fields()
             if (count($itemtypes) > 0) {
                 Plugin::registerClass(
                     'PluginFieldsContainer',
-                    ['addtabon' => $itemtypes,
-                     'forwardentityfrom' => true],
+                    ['addtabon' => $itemtypes],
                 );
             }
 

--- a/setup.php
+++ b/setup.php
@@ -285,7 +285,6 @@ function plugin_fields_checkFiles()
     }
 }
 
-
 function plugin_fields_exportBlockAsYaml($container_id = null)
 {
     /** @var DBmysql $DB */

--- a/setup.php
+++ b/setup.php
@@ -126,7 +126,8 @@ function plugin_init_fields()
             if (count($itemtypes) > 0) {
                 Plugin::registerClass(
                     'PluginFieldsContainer',
-                    ['addtabon' => $itemtypes],
+                    ['addtabon' => $itemtypes,
+                     'forwardentityfrom' => true],
                 );
             }
 
@@ -284,6 +285,7 @@ function plugin_fields_checkFiles()
         }
     }
 }
+
 
 function plugin_fields_exportBlockAsYaml($container_id = null)
 {

--- a/templates/container.class.tpl
+++ b/templates/container.class.tpl
@@ -84,6 +84,10 @@ class %%CLASSNAME%% extends PluginFieldsAbstractContainerInstance
                ]
             )->current();
 
+            if ($related_item === null) {
+                continue;
+            }
+
             //update if needed
             if ($fields['entities_id'] != $related_item['entities_id']) {
                $stmt->bind_param(

--- a/templates/container.class.tpl
+++ b/templates/container.class.tpl
@@ -13,6 +13,7 @@ class %%CLASSNAME%% extends PluginFieldsAbstractContainerInstance
 
       $obj = new self();
       $table = $obj->getTable();
+      $migration = new PluginFieldsMigration(0);
 
       // create Table
       if (!$DB->tableExists($table)) {
@@ -32,10 +33,8 @@ class %%CLASSNAME%% extends PluginFieldsAbstractContainerInstance
          $result = $DB->query("SHOW COLUMNS FROM `$table`");
          if ($result && $DB->numrows($result) > 0) {
             $changed = false;
-            $migration = new PluginFieldsMigration(0);
             while ($data = $DB->fetchAssoc($result)) {
                if (str_starts_with($data['Field'], 'itemtype_') && $data['Null'] !== 'YES') {
-               Toolbox::logDebug($data);
                   $migration->changeField($table, $data['Field'], $data['Field'], "varchar(100) DEFAULT NULL");
                   $changed = true;
                }

--- a/templates/container.class.tpl
+++ b/templates/container.class.tpl
@@ -79,7 +79,7 @@ class %%CLASSNAME%% extends PluginFieldsAbstractContainerInstance
       }
 
       if (getItemForItemtype("%%ITEMTYPE%%")->maybeRecursive() && !$DB->fieldExists($table, 'is_recursive')) {
-         $migration->addField($table, 'is_recursive', 'bool', ['update' => '1', 'after'  => 'entities_id']);
+         $migration->addField($table, 'is_recursive', 'bool', ['after'  => 'entities_id']);
          $migration->addKey($table, 'is_recursive');
          $migration->executeMigration();
          //migrate data

--- a/templates/container.class.tpl
+++ b/templates/container.class.tpl
@@ -139,6 +139,10 @@ class %%CLASSNAME%% extends PluginFieldsAbstractContainerInstance
                ]
             )->current();
 
+            if ($related_item === null) {
+                continue;
+            }
+
             //update if needed
             if ($fields['is_recursive'] != $related_item['is_recursive']) {
                $stmt->bind_param(


### PR DESCRIPTION
## Checklist before requesting a review



*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This PR corrects a behaviour identified in the `fields` plugin. Until now, when calling the API to retrieve one or more containers (`https://<FQDN>/apirest.php/PluginFields<BlockName>`), the plugin did not correctly check the associated access rights and return all data.

This update introduces a systematic rights check for each container retrieved.

Before checl : 

```shell
curl -X GET \
-H 'Content-Type: application/json' \
-H "Session-Token: qcs67di01ckfifaktuenldsu3c" \
-H "App-Token: OtWWECjVh4XjCXtxb0qU1yNF9cA3E5xtl8BOMuHx" \
'http://glpi10bf.local/apirest.php/PluginFieldsTickettest/1?expand_dropdowns=true'
{"id":1,"items_id":"Related ticket","itemtype":"Ticket","plugin_fields_containers_id":"test","texttestfield":"test","links":[{"rel":"Ticket","href":"http://glpi10bf.local/api/Ticket/94"},{"rel":"PluginFieldsContainer","href":"http://glpi10bf.local/api/PluginFieldsContainer/3"}]}%  
```

After : 

```shell
curl -X GET \
-H 'Content-Type: application/json' \
-H "Session-Token: qcs67di01ckfifaktuenldsu3c" \
-H "App-Token: OtWWECjVh4XjCXtxb0qU1yNF9cA3E5xtl8BOMuHx" \
'http://glpi10bf.local/apirest.php/PluginFieldsTickettest/1?expand_dropdowns=true'
["ERROR_RIGHT_MISSING","You don't have permission to perform this action."]%       
```


- It fixes !35164

## Screenshots (if appropriate):

