### PR TITLE
Fix(Generate): generate Dropdown before container

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -264,6 +264,15 @@ function plugin_fields_checkFiles()
     // Clean all existing files
     array_map('unlink', glob(PLUGINFIELDS_DOC_DIR . '/*/*'));
 
+    // Regenerate dropdowns
+    if ($DB->tableExists(PluginFieldsField::getTable())) {
+        $fields_obj = new PluginFieldsField();
+        $fields     = $fields_obj->find(['type' => 'dropdown']);
+        foreach ($fields as $field) {
+            PluginFieldsDropdown::create($field);
+        }
+    }
+
     // Regenerate containers
     if ($DB->tableExists(PluginFieldsContainer::getTable())) {
         $container_obj = new PluginFieldsContainer();
@@ -274,14 +283,6 @@ function plugin_fields_checkFiles()
         }
     }
 
-    // Regenerate dropdowns
-    if ($DB->tableExists(PluginFieldsField::getTable())) {
-        $fields_obj = new PluginFieldsField();
-        $fields     = $fields_obj->find(['type' => 'dropdown']);
-        foreach ($fields as $field) {
-            PluginFieldsDropdown::create($field);
-        }
-    }
 }
 
 function plugin_fields_exportBlockAsYaml($container_id = null)


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #860

This PR adjusts the file regeneration process created by `fields`. 
From now on, the files will be generated in two steps:

- Generation of files related to dropdowns.
- Generation of files related to containers.

This prevents a fatal error when a `container` is added to a `dropdown` created in another `container` (and not yet generated).

## Screenshots (if appropriate):

