### PR TITLE
Prevent destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELAESE]
 
 ### Fixed
-- Ddo not destroy `dropdown` table / class if used by another container
+- Do not destroy the dropdown table/class if it is being used by another container.
 
 ## [1.21.16] - 2024-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELAESE]
 
+### Fixed
+- Ddo not destroy `dropdown` table / class if used by another container
+
 ## [1.21.16] - 2024-11-12
 
 ### Fixed

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -394,15 +394,18 @@ class PluginFieldsField extends CommonDBChild
         ]);
 
         if ($this->fields['type'] === 'dropdown') {
-            //load all container and check if another use this fields
+            //load all container (except current one) and check if another use this fields
             $container_obj = new PluginFieldsContainer();
-            $all_container = $container_obj->find();
+            $all_container = $container_obj->find([
+                'id' => ['!=', $this->fields['plugin_fields_containers_id']]
+            ]);
 
             $use_by_another = false;
             foreach ($all_container as $container_fields) {
                 foreach (json_decode($container_fields['itemtypes']) as $itemtype) {
-                    $classname = PluginFieldsContainer::getClassname($itemtype, $container_fields['name']);
-                    if ($DB->fieldExists(getTableForItemType($classname), $this->fields['name'])) {
+                    $dropdown_classname = PluginFieldsDropdown::getClassname($this->fields['name']);
+                    $dropdown_fk = getForeignKeyFieldForItemType($dropdown_classname);
+                    if ($DB->fieldExists(getTableForItemType($classname), $dropdown_fk)) {
                         $use_by_another = true;
                     }
                 }

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -393,22 +393,24 @@ class PluginFieldsField extends CommonDBChild
             'items_id' => $this->fields['id'],
         ]);
 
-        //load all container and check if another use this fields
-        $container_obj = new PluginFieldsContainer();
-        $all_container = $container_obj->find();
+        if ($this->fields['type'] === 'dropdown') {
+            //load all container and check if another use this fields
+            $container_obj = new PluginFieldsContainer();
+            $all_container = $container_obj->find();
 
-        $use_by_another = false;
-        foreach ($all_container as $container_fields) {
-            foreach (json_decode($container_fields['itemtypes']) as $itemtype) {
-                $classname = PluginFieldsContainer::getClassname($itemtype, $container_fields['name']);
-                if ($DB->fieldExists(getTableForItemType($classname), $this->fields['name'])) {
-                    $use_by_another = true;
+            $use_by_another = false;
+            foreach ($all_container as $container_fields) {
+                foreach (json_decode($container_fields['itemtypes']) as $itemtype) {
+                    $classname = PluginFieldsContainer::getClassname($itemtype, $container_fields['name']);
+                    if ($DB->fieldExists(getTableForItemType($classname), $this->fields['name'])) {
+                        $use_by_another = true;
+                    }
                 }
             }
-        }
 
-        if ($this->fields['type'] === 'dropdown' && !$use_by_another) {
-            return PluginFieldsDropdown::destroy($this->fields['name']);
+            if (!$use_by_another) {
+                return PluginFieldsDropdown::destroy($this->fields['name']);
+            }
         }
 
         return true;

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -396,9 +396,7 @@ class PluginFieldsField extends CommonDBChild
         if ($this->fields['type'] === 'dropdown') {
             //load all container (except current one) and check if another use this fields
             $container_obj = new PluginFieldsContainer();
-            $all_container = $container_obj->find([
-                'id' => ['!=', $this->fields['plugin_fields_containers_id']]
-            ]);
+            $all_container = $container_obj->find(['id' => ['!=', $this->fields['plugin_fields_containers_id']]]);
 
             $use_by_another = false;
             foreach ($all_container as $container_fields) {

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -402,6 +402,7 @@ class PluginFieldsField extends CommonDBChild
             foreach ($all_container as $container_fields) {
                 foreach (json_decode($container_fields['itemtypes']) as $itemtype) {
                     $dropdown_classname = PluginFieldsDropdown::getClassname($this->fields['name']);
+                    $classname = PluginFieldsContainer::getClassname($itemtype, $container_fields['name']);
                     $dropdown_fk = getForeignKeyFieldForItemType($dropdown_classname);
                     if ($DB->fieldExists(getTableForItemType($classname), $dropdown_fk)) {
                         $use_by_another = true;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35567

If two blocks share the same dropdown field, removing it from the first block disrupts the second, as the associated dropdown table/class is deleted while still being referenced elsewhere.

This PR introduces a verification step before deleting a field, ensuring it is not in use by another block, thus preventing data inconsistencies and operational issues.

## Screenshots (if appropriate):

