### PR TITLE
1.21.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELAESE]
 
+## [1.21.16] - 2024-11-12
+
 ### Fixed
 
 - Fix `container` to prevent calls from `API` returning full container data

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,6 +99,11 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
    </authors>
    <versions>
       <version>
+         <num>1.21.16</num>
+         <compatibility>~10.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.16/glpi-fields-1.21.16.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.21.15</num>
          <compatibility>~10.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.15/glpi-fields-1.21.15.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_FIELDS_VERSION', '1.21.15');
+define('PLUGIN_FIELDS_VERSION', '1.21.16');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_FIELDS_MIN_GLPI', '10.0.0');


### PR DESCRIPTION
## [1.21.16] - 2024-11-12

### Fixed

- Fix `container` to prevent calls from `API` returning full container data

