### PR TITLE
Exclude "content" or "_predefined_fields" from the serialized object

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -966,6 +966,9 @@ class PluginFieldsField extends CommonDBChild
             function refreshContainer() {
                 const data = $('#{$html_id}').closest('form').serializeArray().reduce(
                     function(obj, item) {
+                        if (item.name === "content" || item.name === "_predefined_fields") {
+                            return obj;
+                        }
                         var multiple_matches = item.name.match(/^(.+)\[\]$/);
                         if (multiple_matches) {
                             var name = multiple_matches[1];


### PR DESCRIPTION
## Description

- It attempts to fix #870. It ignores the content of the ticket and _predefined_fields (ticket template) so that it is not serialized in the URL. In case of big ticket template, it was generating so huge URLs that it was causing issues with web servers and PHP.

It seems to work properly in my environment but I'm not familiar enough with the code base to know if that the right solution. 

