### PR TITLE
1.21.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Do not destroy the dropdown table/class if it is being used by another container.
 - Fix fields updates with multiple containers via the API.
 
-## [1.21.16] - 2024-16-11
+## [1.21.16] - 2024-12-11
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELAESE]
 
+## [1.21.17] - 2024-12-26
+
 ### Fixed
+
 - Force decimal ‘datatype’ of `numeric` fields  for more accurate display.
 - Do not destroy the dropdown table/class if it is being used by another container.
 - Fix fields updates with multiple containers via the API.
 
-## [1.21.16] - 2024-11-12
+## [1.21.16] - 2024-16-11
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Force decimal ‘datatype’ of `numeric` fields  for more accurate display.
+- Force decimal `datatype` of `numeric` fields  for more accurate display.
 - Do not destroy the dropdown table/class if it is being used by another container.
 - Fix fields updates with multiple containers via the API.
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,6 +99,11 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
    </authors>
    <versions>
       <version>
+         <num>1.21.17</num>
+         <compatibility>~10.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.17/glpi-fields-1.21.17.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.21.16</num>
          <compatibility>~10.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.16/glpi-fields-1.21.16.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_FIELDS_VERSION', '1.21.16');
+define('PLUGIN_FIELDS_VERSION', '1.21.17');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_FIELDS_MIN_GLPI', '10.0.0');


### PR DESCRIPTION
## [1.21.17] - 2024-12-26

### Fixed

- Force decimal `datatype` of `numeric` fields  for more accurate display.
- Do not destroy the dropdown table/class if it is being used by another container.
- Fix fields updates with multiple containers via the API.

