### PR TITLE
Fix(Condition): Fix display when value is no more available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELAESE]
 
+- Fix `PluginFieldsContainerDisplayCondition` display when value is no more available.
+
 ## [1.21.17] - 2024-12-26
 
 ### Fixed

--- a/inc/containerdisplaycondition.class.php
+++ b/inc/containerdisplaycondition.class.php
@@ -313,8 +313,9 @@ class PluginFieldsContainerDisplayCondition extends CommonDBChild
         if ($so['datatype'] == 'dropdown' || ($so['datatype'] == 'itemlink' && $so['table'] !== $itemtypetable)) {
             $dropdown_itemtype = getItemTypeForTable($so['table']);
             $dropdown          = new $dropdown_itemtype();
-            $dropdown->getFromDB($value);
-            $raw_value = $dropdown->fields['name'];
+            if ($dropdown->getFromDB($value)) {
+                $raw_value = $dropdown->fields['name'];
+            }
         } elseif ($so['datatype'] == 'specific' && get_parent_class($itemtype) == CommonITILObject::getType()) {
             switch ($so['field']) {
                 case 'status':


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #900 

An error occurs during display when a `PluginFieldsContainerDisplayCondition` is associated with a dropdown that is no longer available (e.g., deleted).

This PR fix this

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/49915c45-17a4-474a-8b71-8eed2ba672c9)

