### PR TITLE
Fix api container tab update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELAESE]
 
+- Fix container update from `API`
+
 ## [1.21.18] - 2024-01-16
 
 - Fix `PluginFieldsContainerDisplayCondition` display when value is no more available.

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1666,6 +1666,8 @@ HTML;
         //find container (if not exist, do nothing)
         if (isset($_REQUEST['c_id'])) {
             $c_id = $_REQUEST['c_id'];
+        } elseif (isset($item->input['c_id'])) {
+            $c_id = $item->input['c_id'];
         } else {
             $type = 'dom';
             if (isset($_REQUEST['_plugin_fields_type'])) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #835

From `API`, plugin need to check from `$item->input` to get related container instead of check `$_REQUEST` whioch is not relevant from `API` process

## Screenshots (if appropriate):
