### PR TITLE
fix: add default value for dropdown to avoid empty dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELAESE]
 
 - Fix container update from `API`
-- Fix: add default value for dropdown to avoid empty dropdown
+- Fix: fix default value for `dropdown` field to avoid empty dropdown
 
 ## [1.21.18] - 2024-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELAESE]
 
 - Fix container update from `API`
+- Fix: add default value for dropdown to avoid empty dropdown
 
 ## [1.21.18] - 2024-01-16
 

--- a/ajax/field_specific_fields.php
+++ b/ajax/field_specific_fields.php
@@ -119,9 +119,7 @@ if ($type === 'glpi_item') {
         if ($field->isNewItem() && $type == 'dropdown') {
             echo '<em class="form-control-plaintext">';
             echo __s('Default value will be configurable once field will be created.', 'fields');
-            if ($multiple) {
-                echo '<input type="hidden" name="default_value" value="[]" />';
-            } else {
+            if (!$multiple) {
                 echo '<input type="hidden" name="default_value" value="" />';
             }
             echo '</em>';

--- a/ajax/field_specific_fields.php
+++ b/ajax/field_specific_fields.php
@@ -119,11 +119,19 @@ if ($type === 'glpi_item') {
         if ($field->isNewItem() && $type == 'dropdown') {
             echo '<em class="form-control-plaintext">';
             echo __s('Default value will be configurable once field will be created.', 'fields');
+            if ($multiple) {
+                echo '<input type="hidden" name="default_value" value="[]" />';
+            } else {
+                echo '<input type="hidden" name="default_value" value="" />';
+            }
             echo '</em>';
         } else {
             $itemtype = $type == 'dropdown'
                 ? PluginFieldsDropdown::getClassname($field->fields['name'])
                 : $dropdown_matches['class'];
+            if ($field->fields['default_value'] === null) {
+                $field->fields['default_value'] = 0;
+            }
             $default_value = $multiple ? json_decode($field->fields['default_value']) : $field->fields['default_value'];
             Dropdown::show(
                 $itemtype,

--- a/ajax/field_specific_fields.php
+++ b/ajax/field_specific_fields.php
@@ -130,7 +130,7 @@ if ($type === 'glpi_item') {
                 ? PluginFieldsDropdown::getClassname($field->fields['name'])
                 : $dropdown_matches['class'];
             if ($field->fields['default_value'] === null) {
-                $field->fields['default_value'] = 0;
+                $field->fields['default_value'] = '';
             }
             $default_value = $multiple ? json_decode($field->fields['default_value']) : $field->fields['default_value'];
             Dropdown::show(


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #36030
- When creating a dropdown, no default value was defined. In the database, the default value was "NULL" which caused some problems such as not checking the mandatory fields.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/d3427a4d-3841-4fc4-93f6-eefce44a4b1c)

