### PR TITLE
Fix(fields): rely on input first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+### Fixed
+
+- Fix container update from other context (like plugins)
 
 ## [1.21.19] - 2025-02-03
+
+### Fixed
 
 - Fix container update from `API`
 - Fix: fix default value for `dropdown` field to avoid empty dropdown
 
 ## [1.21.18] - 2024-01-16
+
+### Fixed
 
 - Fix `PluginFieldsContainerDisplayCondition` display when value is no more available.
 - Fix issue where the value of custom fields could not be saved

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1664,10 +1664,10 @@ HTML;
     public static function preItem(CommonDBTM $item)
     {
         //find container (if not exist, do nothing)
-        if (isset($_REQUEST['c_id'])) {
-            $c_id = $_REQUEST['c_id'];
-        } elseif (isset($item->input['c_id'])) {
+        if (isset($item->input['c_id'])) {
             $c_id = $item->input['c_id'];
+        } elseif (isset($_REQUEST['c_id'])) {
+            $c_id = $_REQUEST['c_id'];
         } else {
             $type = 'dom';
             if (isset($_REQUEST['_plugin_fields_type'])) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Unable to update fields from Formcreator plugin (which add `c_id` to input)

So rely on input first (see with Formcreator plugin)

## Screenshots (if appropriate):
