### PR TITLE
fix(searchOption): notequals operator returns equals values for multiple dropdown

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -357,7 +357,12 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
             ],
         )
     ) {
-        return $link . $DB->quoteName("$table" . '_' . "$field") . '.' . $DB->quoteName($field) . 'LIKE ' . $DB->quoteValue("%\"$val\"%") ;
+        switch ($searchtype) {
+            case 'equals':
+                return $link . $DB->quoteName("$table" . '_' . "$field") . '.' . $DB->quoteName($field) . 'LIKE ' . $DB->quoteValue("%\"$val\"%") ;
+            case 'notequals':
+                return $link . $DB->quoteName("$table" . '_' . "$field") . '.' . $DB->quoteName($field) . 'LIKE ' . $DB->quoteValue("%\"$val\"%") ;
+        }
     } else {
         // if 'multiple' field with cleaned name is found -> 'dropdown' case
         // update WHERE clause with LIKE statement
@@ -371,7 +376,13 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
                 ],
             )
         ) {
-            return $link . $DB->quoteName("$table" . '_' . "$cleanfield") . '.' . $DB->quoteName($field) . 'LIKE ' . $DB->quoteValue("%\"$val\"%") ;
+            switch ($searchtype) {
+                case 'equals':
+                    return $link . $DB->quoteName("$table" . '_' . "$cleanfield") . '.' . $DB->quoteName($field) . 'LIKE ' . $DB->quoteValue("%\"$val\"%") ;
+                case 'notequals':
+                    return $link . $DB->quoteName("$table" . '_' . "$cleanfield") . '.' . $DB->quoteName($field) . 'NOT LIKE ' . $DB->quoteValue("%\"$val\"%") . ' OR ' . $link . $DB->quoteName("$table" . '_' . "$cleanfield") . '.' . $DB->quoteName($field) . 'IS NULL ';
+
+            }
         } else {
             return false;
         }


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36795
- The operator is not had the same behavior as the operator is in the search options for multiple choice dropdown

![Capture d’écran du 2025-03-13 13-30-21](https://github.com/user-attachments/assets/c4837501-e9b6-4d0b-9051-fd3bb0f1cdda)
