### PR TITLE
Fix(Container): save entites_id manually from container type 'dom'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix containers migration while adding `is_recursive` field
 - Fix container update from other context (like plugins)
 - Fix "not equals" search operator for dropdown `multiple`
+- Fix container data (`entities_id`) insert from `dom` type
 
 ## [1.21.19] - 2025-02-03
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1618,6 +1618,7 @@ HTML;
         if (array_key_exists('_plugin_fields_data', $item->input)) {
             $data             = $item->input['_plugin_fields_data'];
             $data['items_id'] = $item->getID();
+            $data['entities_id'] = $item->isEntityAssign() ? $item->getEntityID() : 0;
             //update data
             $container = new self();
             if ($container->updateFieldsValues($data, $item->getType(), isset($_REQUEST['massiveaction']))) {
@@ -1644,6 +1645,7 @@ HTML;
         self::preItem($item);
         if (array_key_exists('_plugin_fields_data', $item->input)) {
             $data = $item->input['_plugin_fields_data'];
+            $data['entities_id'] = $item->isEntityAssign() ? $item->getEntityID() : 0;
             //update data
             $container = new self();
             if (


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36465

When a container is defined as type `dom` (displayed before the save button), the data entry process differs from that in `tab` mode. It is necessary to manually add the `entities_id` to ensure it is recorded in the container's table

## Screenshots (if appropriate):
