### PR TITLE
Fix(core): Hide fields 'tab' from template as it's content is not display

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1138,6 +1138,11 @@ HTML;
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
+        if ($withtemplate) {
+            //Do not display tab from template or from item created from template
+            return '';
+        }
+
         $itemtypes = self::getEntries('tab', true);
         if (isset($itemtypes[$item->getType()]) && $item instanceof CommonDBTM) {
             $tabs_entries = [];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes N/A
Hide fields 'tab' from template as it's content is not display

Like 

```php
    public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
    {
        if ($withtemplate) {
            //Do not display tab from template or from item created from template
            return false;
        }

```

but for 

```public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)``` 

## Screenshots (if appropriate):
