### PR TITLE
1.21.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+## [1.21.20] - 2025-03-20
+
 ### Fixed
 
 - Fix `numeric` field search

--- a/plugin.xml
+++ b/plugin.xml
@@ -100,7 +100,7 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
    <versions>
       <version>
          <num>1.21.20</num>
-         <compatibility>~10.0.0</compatibility>
+         <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.20/glpi-fields-1.21.20.tar.bz2</download_url>
       </version>
       <version>

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,6 +99,11 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
    </authors>
    <versions>
       <version>
+         <num>1.21.20</num>
+         <compatibility>~10.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.20/glpi-fields-1.21.20.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.21.19</num>
          <compatibility>~10.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.19/glpi-fields-1.21.19.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_FIELDS_VERSION', '1.21.19');
+define('PLUGIN_FIELDS_VERSION', '1.21.20');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_FIELDS_MIN_GLPI', '10.0.11');


### PR DESCRIPTION
## [1.21.20] - 2025-03-20

### Fixed

- Fix `numeric` field search
- Fix containers migration while adding `is_recursive` field
- Fix container update from other context (like plugins)
- Fix "not equals" search operator for dropdown `multiple`
- Fix container data (`entities_id`) insert from `dom` type