### PR TITLE
1.21.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+## [1.21.21] - 2025-03-21
+
 ### Fixed
 
 - Fix of GLPI native fields update for objects with `fields` containers.

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,6 +99,11 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
    </authors>
    <versions>
       <version>
+         <num>1.21.21</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.21/glpi-fields-1.21.21.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.21.20</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.20/glpi-fields-1.21.20.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-define('PLUGIN_FIELDS_VERSION', '1.21.20');
+define('PLUGIN_FIELDS_VERSION', '1.21.21');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_FIELDS_MIN_GLPI', '10.0.11');


### PR DESCRIPTION
## [1.21.21] - 2025-03-21

### Fixed

- Fix of GLPI native fields update for objects with `fields` containers.