### PR TITLE
Fix - Validation for mandatory multiple dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+### Fixed
+
+- Fix validation for mandatory multiple dropdown
+
 ## [1.21.21] - 2025-03-21
 
 ### Fixed

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1521,9 +1521,7 @@ HTML;
             if (
                 $field['mandatory'] == 1
                 && (
-                    $value === null
-                    || $value === ''
-                    || (is_array($value) && empty($value))
+                    empty($value)
                     || (($field['type'] === 'dropdown' || preg_match('/^dropdown-.+/i', $field['type'])) && $value == 0)
                     || (in_array($field['type'], ['date', 'datetime']) && $value == 'NULL')
                 )

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1523,6 +1523,7 @@ HTML;
                 && (
                     $value === null
                     || $value === ''
+                    || (is_array($value) && empty($value))
                     || (($field['type'] === 'dropdown' || preg_match('/^dropdown-.+/i', $field['type'])) && $value == 0)
                     || (in_array($field['type'], ['date', 'datetime']) && $value == 'NULL')
                 )


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !37010
- Here is a brief description of what this PR does

If a required multiple dropdown field is present in our ticket form, it is currently possible to create a ticket without selecting any values.

The issue comes from the validation function, which only checks if a required field is empty but does not properly handle multiple-selection fields. For a standard dropdown, the function considers a value of 0 as empty. However, for a multiple dropdown, an unselected field results in an empty array, which is not detected as invalid.

A specific condition must be added to check if a required multiple-selection field is empty by detecting empty arrays during validation.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/e3707861-8051-481d-aba3-68f2017d597a)
