### PR TITLE
fix(SO): search options not working with default values in multi-select

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -376,7 +376,6 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
             }
         }
     }
-
     // if 'multiple' field with name is found -> 'Dropdown-XXXX' case
     // update WHERE clause with LIKE statement
     if (
@@ -390,9 +389,9 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
         $tablefield = "$table" . '_' . "$field";
         switch ($searchtype) {
             case 'equals':
-                return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'notequals' : 'equals');
+                return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'notequals' : 'equals', $itemtype, $field_field);
             case 'notequals':
-                return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'equals' : 'notequals');
+                return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'equals' : 'notequals', $itemtype, $field_field);
         }
     } else {
         // if 'multiple' field with cleaned name is found -> 'dropdown' case
@@ -410,9 +409,9 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
         ) {
             switch ($searchtype) {
                 case 'equals':
-                    return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'notequals' : 'equals');
+                    return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'notequals' : 'equals', $itemtype, $field_field);
                 case 'notequals':
-                    return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'equals' : 'notequals');
+                    return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'equals' : 'notequals', $itemtype, $field_field);
             }
         } else {
             return false;

--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -255,16 +255,32 @@ class PluginFieldsDropdown
         return 'PluginFields' . ucfirst($system_name) . 'Dropdown';
     }
 
-    public static function multipleDropdownAddWhere($link, $tablefield, $field, $val, $searchtype)
+    public static function multipleDropdownAddWhere($link, $tablefield, $field, $val, $searchtype, $itemtype, $field_field)
     {
         /** @var \DBmysql $DB */
         global $DB;
 
+        $default_value_request = "";
+
+        if ($field_field->fields['default_value'] === '["' . $val . '"]') {
+            switch ($searchtype) {
+                case 'equals':
+                    $default_value_request = ' OR (' . $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName('itemtype') . ' IS NULL' .
+                    ' AND ' . $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName('items_id') . ' IS NULL)';
+                    break;
+                case 'notequals':
+                    $default_value_request = ' AND (' . $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName('itemtype') . '=' . $DB->quoteValue($itemtype) .
+                    ' OR ' . $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName('items_id') . '=' . $itemtype::getTable() . '.id)';
+                    break;
+            }
+        }
+
         switch ($searchtype) {
             case 'equals':
-                return $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName($field) . 'LIKE ' . $DB->quoteValue("%\"$val\"%") ;
+                return $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName($field) . ' LIKE ' . $DB->quoteValue("%\"$val\"%") . $default_value_request;
             case 'notequals':
-                return $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName($field) . 'NOT LIKE ' . $DB->quoteValue("%\"$val\"%") . ' OR ' . $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName($field) . 'IS NULL ';
+                return $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName($field) . ' NOT LIKE ' . $DB->quoteValue("%\"$val\"%") .
+                ' OR ' . $link . $DB->quoteName($tablefield) . '.' . $DB->quoteName($field) . ' IS NULL' . $default_value_request;
         }
     }
 }


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38487

When a multiple drop-down list field, defined via the Fields plugin, has a default value, this is displayed in the interface when a new item is created (itemtype), but is not saved in the database.

This leads to inconsistent behavior: when GLPI filters search for this value, items supposed to have this default value are not found, as it is not actually saved.

## Screenshots (if appropriate):
<img width="1240" height="762" alt="image" src="https://github.com/user-attachments/assets/4bdfedbe-ca99-4f8d-8c1a-f4639c96f30a" />
<img width="1004" height="669" alt="image" src="https://github.com/user-attachments/assets/b06861b4-163a-43de-84ad-3e69cf34e2ca" />


