### PR TITLE
fix(searchoption): default value not displayed when field is not set

### DIFF
--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -158,8 +158,10 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBChild
                 && $field_specs->fields['multiple']
             ) {
                 $itemtype = PluginFieldsDropdown::getClassname($field_specs->fields['name']);
-                if (empty($values[$field])) {
+                if (empty($values[$field]) && empty($field_specs->fields["default_value"])) {
                     return ''; // Value not defined
+                } elseif (empty($values[$field]) && !empty($field_specs->fields["default_value"])) {
+                    $values[$field] = $field_specs->fields['default_value'];
                 }
                 $values = json_decode($values[$field]);
                 if (!is_array($values)) {


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38487
- When creating an object that has fields in a tab created by the field plugin, if the fields have a default value, they are not saved to the database. In this case, I check whether the row is saved to the database. If the value is not present, the default value is displayed.

## Screenshots (if appropriate):

**Before:**
<img width="1156" height="713" alt="image" src="https://github.com/user-attachments/assets/715e8421-9028-42d5-8884-a83f90277b06" />

**After:**
<img width="1156" height="713" alt="image" src="https://github.com/user-attachments/assets/202c3b65-d3f1-47d2-bcff-20940dacc3a6" />

