### PR TITLE
Fix: search on multi-dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- Fix `search option` for `multiple` dropdown
+
 ## [1.21.23] - 2025-08-26
 
-- FIx undefined array key `multiple_dropdown_action` during import
+### Fixed
+
+- Fix undefined array key `multiple_dropdown_action` during import
 - Fix incompatibility of `multiple` dropdowns with `massiveaction`
 - Fix default value properly applied in multiple dropdown search options
 - Fix `search option` for default values in `multiple` dropdown
@@ -15,11 +23,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The field name was empty in the GLPI logs
 
 ### Added
+
 - Add `replace` and `add` options in massive action for the multiple dropdowns fields
 
 ## [1.21.22] - 2025-05-28
 
 ### Fixed
+
 - Fix condition check logic for dropdown field values
 - Fix validation for mandatory multiple dropdown
 - Fix `twig` error about undefined `dropdown_options`

--- a/hook.php
+++ b/hook.php
@@ -400,9 +400,9 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
         $tablefield = "$table" . '_' . "$field";
         switch ($searchtype) {
             case 'equals':
-                return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'notequals' : 'equals', $itemtype, $field_field);
+                return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'notequals' : 'equals', $field_field);
             case 'notequals':
-                return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'equals' : 'notequals', $itemtype, $field_field);
+                return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'equals' : 'notequals', $field_field);
         }
     } else {
         // if 'multiple' field with cleaned name is found -> 'dropdown' case
@@ -420,9 +420,9 @@ function plugin_fields_addWhere($link, $nott, $itemtype, $ID, $val, $searchtype)
         ) {
             switch ($searchtype) {
                 case 'equals':
-                    return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'notequals' : 'equals', $itemtype, $field_field);
+                    return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'notequals' : 'equals', $field_field);
                 case 'notequals':
-                    return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'equals' : 'notequals', $itemtype, $field_field);
+                    return PluginFieldsDropdown::multipleDropdownAddWhere($link, $tablefield, $field, $val, $nott ? 'equals' : 'notequals', $field_field);
             }
         } else {
             return false;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39008

The “is not” search on a multiple dropdown field was not working.

## Screenshots (if appropriate):
