### PR TITLE
Fix massive action add multiple dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix  `massive action` for adding value to `multiple` dropdown fields
 - Fix `search option` for `multiple` dropdown
 
 ## [1.21.23] - 2025-08-26

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1241,7 +1241,8 @@ HTML;
                     // Add new values to existing ones
                     $existing_values = json_decode($obj->fields[$field_name] ?? '[]', true);
                     $new_values      = is_array($data[$field_name]) ? $data[$field_name] : [$data[$field_name]];
-                    $data[$field_name] = json_encode(array_unique(array_merge($existing_values, $new_values)));
+                    $data[$field_name] = json_encode(array_values(array_unique(array_merge($existing_values, $new_values))));
+
                 } else {
                     $data[$field_name] = json_encode($data[$field_name]);
                 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38850
- Here is a brief description of what this PR does
Correction of the bulk action to add value to multiple drop-down fields, specifically the ‘Add’ option, which now compares the values in the table rather than the keys in order to prevent duplicates.

## Screenshots (if appropriate):

