### PR TITLE
[Bug] Block name not displayed as clickable link in Fields plugin list

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -2243,7 +2243,7 @@ HTML;
 
     public static function getNameField()
     {
-        return 'label';
+        return 'name';
     }
 
     public function prepareInputForClone($input)


### PR DESCRIPTION
The getNameField() method returns 'label' instead of 'name', so the CommonDBTM logic does not render a link.

## Bug Description

When viewing the list of blocks in **Setup → Plugins → Fields → Blocks**,  the column **Name** shows plain text instead of a clickable link to edit the block.

**Expected behavior:**  
Each block name should appear as a clickable hyperlink to the block’s form.

## Steps to Reproduce

1. Go to *Setup → Plugins → Fields → Blocks*  
2. View the list of existing blocks  
3. Observe that the “Name” column is not clickable  

## Expected Result

The “Name” column should contain clickable links leading to the edit form of each block.

## Root Cause

In `inc/container.class.php`, the method:

```php
public static function getNameField()
{
    return 'label';
}
```

The rawSearchOptions() method defines:

```php
[
 'id'            => 1,
 'table'         => self::getTable(),
 'field'         => 'name',
 'name'          => __('Name'),
 'datatype'      => 'itemlink',
 'itemlink_type' => self::getType(),
 'massiveaction' => false,
]
```

Because getNameField() returns 'label' instead of 'name', the GLPI core (CommonDBTM) does not render the itemlink as a hyperlink.

## Proposed Fix
Option 1 (Applied)

Change the return value of getNameField():

```php
public static function getNameField()
{
    return 'label';
}
```

## Option 2 (Alternative)

Modify rawSearchOptions():

```php
'field' => self::getNameField(),
```

Either option restores proper linking behavior.

## Result

After applying the fix, the block name is displayed as a clickable link that opens the block edit form.