### PR TITLE
Fix: foreach() argument must be of type array|object

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -237,9 +237,13 @@ class PluginFieldsContainer extends CommonDBTM
         $obj        = new self();
         $containers = $obj->find();
         foreach ($containers as $container) {
-            $itemtypes = !empty($container['itemtypes'])
-                ? json_decode($container['itemtypes'], true)
-                : [];
+            $itemtypes = [];
+            if (!empty($container['itemtypes'])) {
+                $decoded = json_decode($container['itemtypes'], true);
+                if (is_array($decoded)) {
+                    $itemtypes = $decoded;
+                }
+            }
 
             foreach ($itemtypes as $itemtype) {
                 $sysname        = self::getSystemName($itemtype, $container['name']);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38732

Avoid this error in the logs:
```
glpi.WARNING:   *** Warning: foreach() argument must be of type array|object, null given at container.class.php line 244
  Backtrace :
  ./marketplace/fields/inc/container.class.php:244   
  ./marketplace/fields/hook.php:87                   PluginFieldsContainer::installUserData()
  ./src/Plugin.php:1160                              plugin_fields_install()
  :                                                  Plugin->install()
  ./src/Glpi/Marketplace/Controller.php:655          call_user_func()
  ./src/Glpi/Marketplace/Controller.php:545          Glpi\Marketplace\Controller->setPluginState()
  ./ajax/marketplace.php:63                          Glpi\Marketplace\Controller->installPlugin()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()
```

## Screenshots (if appropriate):
