### PR TITLE
Fix - Prevent unnecessary container refresh breaking mandatory field validation

### DIFF
--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -995,6 +995,9 @@ class PluginFieldsField extends CommonDBChild
                     {}
                 );
 
+                // Check current visibility state before refresh
+                const wasVisible = $('#{$html_id}').children().length > 0;
+
                 $.ajax(
                     {
                         url: '{$ajax_url}',
@@ -1009,10 +1012,18 @@ class PluginFieldsField extends CommonDBChild
                             input:    data
                         },
                         success: function(data) {
-                            // Close open select2 dropdown that will be replaced
-                            $('#{$html_id}').find('.select2-hidden-accessible').select2('close');
-                            // Refresh fields HTML
-                            $('#{$html_id}').html(data);
+                            // Check if visibility will change
+                            const willBeVisible = data.trim() !== '';
+
+                            // Only refresh if visibility state changes
+                            // This prevents unnecessary DOM replacement that breaks validation event listeners
+                            if (wasVisible !== willBeVisible) {
+                                // Close open select2 dropdown that will be replaced
+                                $('#{$html_id}').find('.select2-hidden-accessible').select2('close');
+
+                                // Refresh fields HTML
+                                $('#{$html_id}').html(data);
+                            }
                         }
                     }
                 );


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/pluginsGLPI/fields/issues/1041
- Here is a brief description of what this PR does

### Problem
After upgrading to GLPI 11, tickets with mandatory dropdown fields from the Fields plugin couldn't be saved. The Save button did nothing even when valid values were selected.

**Root cause:** 
- GLPI PR glpi-project/glpi#21092 introduced strict validation for mandatory fields using `addEventListener` on form submit
- Container refresh triggered on every form field change (category, priority, etc.)
- Each refresh generated new random DOM IDs for dropdowns
- Validation event listeners remained attached to old (removed) elements with old IDs
- Forms blocked because validation checked non-existent DOM elements

### Solution
Only refresh the container when its visibility state actually changes (from empty to visible or vice versa). This prevents unnecessary DOM replacement that breaks validation event listeners attached by GLPI core.


## Screenshots (if appropriate):
