### PR TITLE
fix(forms): Make mandatory fields optional in the editor

### DIFF
--- a/templates/question_type_administration.html.twig
+++ b/templates/question_type_administration.html.twig
@@ -32,12 +32,13 @@
 
 {% set is_ajax_reload = is_ajax_reload|default(false) %}
 
-{% set field = field|merge({
-    'default_value': default_value ?? field.default_value
+{% set field_for_html = field|merge({
+    'default_value': default_value ?? field.default_value,
+    'mandatory': false
 }) %}
 
 {{ call('PluginFieldsField::prepareHtmlFields', [
-    [field],
+    [field_for_html],
     item,
     true,
     true,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.

## Description

When an additional field is mandatory and is used in a `Field` type question, its mandatory attribute interferes with the default value functionality (which is optional) of the form editor.

This fix ensures that the mandatory nature of the field is always negative when editing a question.