### PR TITLE
fix $item->input that could not be an array in container.class.php

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1626,7 +1626,7 @@ HTML;
      */
     public static function postItemAdd(CommonDBTM $item)
     {
-        if (array_key_exists('_plugin_fields_data', $item->input)) {
+        if (is_array($item->input) && array_key_exists('_plugin_fields_data', $item->input)) {
             $data             = $item->input['_plugin_fields_data'];
             $data['items_id'] = $item->getID();
             $data['entities_id'] = $item->isEntityAssign() ? $item->getEntityID() : 0;
@@ -1654,7 +1654,7 @@ HTML;
     public static function preItemUpdate(CommonDBTM $item)
     {
         self::preItem($item);
-        if (array_key_exists('_plugin_fields_data', $item->input)) {
+        if (is_array($item->input) && array_key_exists('_plugin_fields_data', $item->input)) {
             $data = $item->input['_plugin_fields_data'];
             $data['entities_id'] = $item->isEntityAssign() ? $item->getEntityID() : 0;
             //update data


### PR DESCRIPTION
fix if $item->input not an array

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):
