### PR TITLE
fix: Unable to populate additional fields because the itemtype is missing from DB request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a bug that prevented the creation of additional field data for objects
+
 ## [1.23.0] - 2025-11-05
 
 ### Added

--- a/inc/abstractcontainerinstance.class.php
+++ b/inc/abstractcontainerinstance.class.php
@@ -33,8 +33,6 @@ abstract class PluginFieldsAbstractContainerInstance extends CommonDBChild
     public static $itemtype = 'itemtype';
     public static $items_id = 'items_id';
 
-    public static $mustBeAttached     = false;
-
     /**
      * This function relies on the static property `static::$plugins_forward_entity`,
      * which should be populated using the following method (from setup):

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1745,6 +1745,7 @@ HTML;
     {
         if (array_key_exists('_plugin_fields_data', $item->input)) {
             $data             = $item->input['_plugin_fields_data'];
+            $data['itemtype'] = $item::class;
             $data['items_id'] = $item->getID();
             $data['entities_id'] = $item->isEntityAssign() ? $item->getEntityID() : 0;
             //update data


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [X] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Ensures that the `itemtype` is explicitly set in the plugin fields data, rather than relying on the default value in the database (this technique no longer works since 11.0.3 of the core)