### PR TITLE
Fix the add operations when a linked object already exists before the plugin container fields are created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix `add` operations when a linked object already exists before the plugin container fields are created.
+
 ### Fixed
 
 - Fix left side menu url (with `DIR_MARKETPLACE`)

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1780,6 +1780,7 @@ HTML;
         self::preItem($item);
         if (array_key_exists('_plugin_fields_data', $item->input)) {
             $data = $item->input['_plugin_fields_data'];
+            $data['itemtype'] = $item::class;
             $data['entities_id'] = $item->isEntityAssign() ? $item->getEntityID() : 0;
             //update data
             $container = new self();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Fix add operations when a linked object already exists before the plugin container fields are created.

Plugin silently failed during `add` operation.

(discovery during debugging another problem)

This PR follow https://github.com/pluginsGLPI/fields/pull/1083
## Screenshots (if appropriate):
