### PR TITLE
1.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.23.1] - 2025-11-20
+
 - Fix `add` operations when a linked object already exists before the plugin container fields are created.
-
-### Fixed
-
 - Fix left side menu url (with `DIR_MARKETPLACE`)
 - Fix default value format for multiple dropdown (GLPIObject)
 - Fix bad SQL query for `GenericObject`

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,6 +99,11 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
    </authors>
    <versions>
       <version>
+         <num>1.23.1</num>
+         <compatibility>~11.0.2</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.23.1/glpi-fields-1.23.1.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.23.0</num>
          <compatibility>~11.0.2</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.23.0/glpi-fields-1.23.0.tar.bz2</download_url>
@@ -107,6 +112,11 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
          <num>1.22.2</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.22.2/glpi-fields-1.22.2.tar.bz2</download_url>
+      </version>
+      <version>
+         <num>1.21.25</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.25/glpi-fields-1.21.25.tar.bz2</download_url>
       </version>
       <version>
          <num>1.21.24</num>

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 /** @var array $CFG_GLPI */
 global $CFG_GLPI;
 
-define('PLUGIN_FIELDS_VERSION', '1.23.0');
+define('PLUGIN_FIELDS_VERSION', '1.23.1');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_FIELDS_MIN_GLPI', '11.0.2');


### PR DESCRIPTION
## [1.23.1] - 2025-11-20

- Fix `add` operations when a linked object already exists before the plugin container fields are created.
- Fix left side menu url (with `DIR_MARKETPLACE`)
- Fix default value format for multiple dropdown (GLPIObject)
- Fix bad SQL query for `GenericObject`
- Fixed a bug that prevented the creation of additional field data for objects
- Hide config menu if user does not have read permission


Need release for GLPI 10bugfixes