### PR TITLE
fix: Fixed field deletion blocked when at least one form question use another field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix error when submitting a form with an hidden question of type `Field`
+- Fixed a bug where a field was deleted when at least one question in a form was linked to another field
 
 ## [1.23.4] - 2026-03-26
 

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -355,9 +355,10 @@ class PluginFieldsField extends CommonDBChild
         $question = new Question();
         $found = $question->find([
             'type' => PluginFieldsQuestionType::class,
-            $this->fields['id'] => new QueryExpression(sprintf(
-                "JSON_VALUE(%s, '$.field_id')",
+            new QueryExpression(sprintf(
+                "JSON_VALUE(%s, '$.field_id') = %s",
                 DBmysql::quoteName('extra_data'),
+                DBmysql::quoteValue((int) $this->fields['id']),
             )),
         ]);
         if (!empty($found)) {

--- a/tests/Units/FieldQuestionTypeTest.php
+++ b/tests/Units/FieldQuestionTypeTest.php
@@ -188,6 +188,60 @@ final class FieldQuestionTypeTest extends QuestionTypeTestCase
         ]);
     }
 
+    public function testFieldDeletionWhenUsedInForm(): void
+    {
+        $this->login();
+
+        // Arrange: create form with Field question
+        $builder = new FormBuilder("My form");
+        $builder->addQuestion(
+            "My question",
+            PluginFieldsQuestionType::class,
+            extra_data: json_encode($this->getFieldExtraDataConfig('glpi_item')),
+        );
+        $this->createForm($builder);
+
+        // Act: try to delete field
+        $response = $this->fields['glpi_item']->delete($this->fields['glpi_item']->fields);
+
+        // Assert: deletion is blocked with appropriate message
+        $this->assertFalse($response);
+        $this->hasSessionMessageThatContains('The field &quot;GLPI Item&quot; cannot be deleted because it is used in a form question', ERROR);
+    }
+
+    public function testFieldDeletionWhenNotUsedInForm(): void
+    {
+        $this->login();
+
+        // Act: try to delete field
+        $response = $this->fields['glpi_item']->delete($this->fields['glpi_item']->fields);
+
+        // Assert: deletion is successful
+        $this->assertTrue($response);
+        $this->hasNoSessionMessage(ERROR);
+    }
+
+    public function testFieldDeletionWhenAnotherFieldUsedInForm(): void
+    {
+        $this->login();
+
+        // Arrange: create form with Field question using dropdown field
+        $builder = new FormBuilder("My form");
+        $builder->addQuestion(
+            "My question",
+            PluginFieldsQuestionType::class,
+            extra_data: json_encode($this->getFieldExtraDataConfig('dropdown')),
+        );
+        $this->createForm($builder);
+
+        // Act: try to delete glpi_item field which isn't used in form but exists
+        $response = $this->fields['glpi_item']->delete($this->fields['glpi_item']->fields);
+
+        // Assert: deletion is successful and not blocked by the fact that another field is used in form
+        $this->assertTrue($response);
+        $this->hasNoSessionMessage(ERROR);
+    }
+
     public function testGetConditionHandlersForDropdownFieldIncludesItemHandlers(): void
     {
         $question_type = new PluginFieldsQuestionType();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [X] I have added tests (when available) that prove my fix is effective or that my feature works.
- [X] I have updated the CHANGELOG with a short functional description of the fix or new feature.

## Description

- #1173 must be merged before
- It fixes !43103

Currently, if a question is of the `Field` type and uses a field, it is no longer possible to delete any field, regardless of its parent block.
This PR fixes this behavior by ensuring that deletion is blocked only for fields that are actually used in a form.