### PR TITLE
Fix (UI) - Text area fields alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- Fix text area fields alignment
+
 ## [1.23.4] - 2026-03-26
 
 ### Fixed

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -36,9 +36,7 @@
 {% endif %}
 
 {% if not already_wrapped and not dropdown_item%}
-
-{% set class = item.isNewItem() or item is instanceof('User') ? 'col-xxl-12' : 'col-xxl-9' %}
-    <div class="col-12  {{ class }} flex-column">
+    <div class="col-12 col-xxl-12 flex-column">
         <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
             <div class="row flex-row align-items-start flex-grow-1">
                 <div class="row flex-row">

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -28,15 +28,47 @@
 
 {% import 'components/form/fields_macros.html.twig' as macros %}
 
-{% set already_wrapped = item is instanceof('CommonITILObject') and container.fields['type'] == 'dom' %}
-{% set dropdown_item = item is instanceof('CommonDropdown') and container.fields['type'] == 'dom' %}
+{% set in_itilobject   = item is instanceof('CommonITILObject') and container.fields['type'] == 'dom' %}
+{% set in_form_builder = item is instanceof('Glpi\\Form\\Form') %}
+{% set already_wrapped = in_itilobject or in_form_builder %}
+{% set dropdown_item   = item is instanceof('CommonDropdown') and container.fields['type'] == 'dom' %}
 
-{% if item is instanceof('Glpi\\Form\\Form') %}
-    {% set already_wrapped = true %}
+{% set textarea_display_options = {
+    'in_itilobject': {
+        'field_class': 'col-12',
+        'label_class': 'col-2',
+        'input_class': 'col-10',
+        'is_horizontal': true,
+        'align_label_right': true,
+    },
+    'in_form_builder': {
+        'field_class': 'col-12',
+        'label_class': 'form-label',
+        'input_class': 'w-100',
+        'is_horizontal': false,
+        'align_label_right': false,
+    },
+    'default': {
+        'field_class': 'col-12',
+        'label_class': 'col-xxl-2',
+        'input_class': 'col-xxl-10',
+        'is_horizontal': true,
+        'align_label_right': true,
+    },
+} %}
+
+{% if in_itilobject %}
+    {% set current_textarea_options = textarea_display_options.in_itilobject %}
+{% elseif in_form_builder %}
+    {% set current_textarea_options = textarea_display_options.in_form_builder %}
+{% else %}
+    {% set current_textarea_options = textarea_display_options.default %}
 {% endif %}
 
 {% if not already_wrapped and not dropdown_item%}
-    <div class="col-12 col-xxl-12 flex-column">
+
+{% set class = item.isNewItem() or item is instanceof('User') or container.fields['type'] == 'dom' ? 'col-xxl-12' : 'col-xxl-9' %}
+    <div class="col-12  {{ class }} flex-column">
         <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
             <div class="row flex-row align-items-start flex-grow-1">
                 <div class="row flex-row">
@@ -86,14 +118,11 @@
             })) }}
 
     {% elseif type == 'textarea' %}
-        {{ macros.textareaField(input_name, value, label, field_options) }}
+        {{ macros.textareaField(input_name, value, label, field_options|merge(current_textarea_options)) }}
 
     {% elseif type == 'richtext' %}
-        {{ macros.textareaField(input_name, value, label, field_options|merge({
+        {{ macros.textareaField(input_name, value, label, field_options|merge(current_textarea_options)|merge({
             'enable_richtext': true,
-            'field_class': 'col-12',
-            'label_class': 'col-xxl-2',
-            'input_class': 'col-xxl-10',
         })) }}
 
     {% elseif type == 'yesno' %}

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -94,9 +94,8 @@
         {{ macros.textareaField(input_name, value, label, field_options|merge({
             'enable_richtext': true,
             'field_class': 'col-12',
-            'label_class': '',
-            'input_class': '',
-            'align_label_right': false,
+            'label_class': 'col-xxl-2',
+            'input_class': 'col-xxl-10',
         })) }}
 
     {% elseif type == 'yesno' %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !42921
- Here is a brief description of what this PR does

In form rendering, text area fields are not aligned correctly.

- **Removed** `label_class : ""` and `input_class: ""` — these empty strings were overriding the default values (`col-xxl-5` / `col-xxl-7`) of the `horizontalField` macro, breaking the alignment
- **Removed** `align_label_right: false` — the rich text label was no longer aligned to the right like the other fields
- **Added** `label_class: col-xxl-2` and `input_class: col-xxl-10` — this exactly matches the style that GLPI core uses for its own rich text fields (e.g., “Description” in project tasks), with a narrow label to maximize editor space.

## Screenshots (if appropriate):

Before : 

<img width="1637" height="659" alt="image" src="https://github.com/user-attachments/assets/22e19e6c-dc22-4820-acf9-41f0a7af4406" />


After : 

<img width="1551" height="630" alt="image" src="https://github.com/user-attachments/assets/91d0c7af-434b-48f2-a832-b67321dadfa7" />
