### PR TITLE
Fix - Avoid SQL warning when no user session is active during plugin init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix SQL warning when no user session is active during plugin init
 - Fix error when submitting a form with an hidden question of type `Field`
 - Fixed a bug where a field was deleted when at least one question in a form was linked to another field
 

--- a/inc/questiontype.class.php
+++ b/inc/questiontype.class.php
@@ -380,7 +380,17 @@ final class PluginFieldsQuestionType extends AbstractQuestionType implements For
         $field_container  = new PluginFieldsContainer();
         $available_blocks = [];
 
-        $entity_restrict = (isCommandLine() || !Session::getLoginUserID()) ? [] : getEntitiesRestrictCriteria(PluginFieldsContainer::getTable(), '', '', true);
+        $entity_restrict = isCommandLine() ? [] : getEntitiesRestrictCriteria(PluginFieldsContainer::getTable(), '', '', true);
+
+        // If entity restriction contains an empty string value, it means no valid session
+        // is active. Running the query would produce a MySQL
+        // warning (1292: Truncated incorrect DECIMAL value)
+        foreach ($entity_restrict as $criterion) {
+            if (is_array($criterion) && in_array('', $criterion, true)) {
+                return $available_blocks;
+            }
+        }
+
         $result           = $field_container->find([
             'is_active' => 1,
             'type'      => 'dom',

--- a/inc/questiontype.class.php
+++ b/inc/questiontype.class.php
@@ -380,7 +380,7 @@ final class PluginFieldsQuestionType extends AbstractQuestionType implements For
         $field_container  = new PluginFieldsContainer();
         $available_blocks = [];
 
-        $entity_restrict = isCommandLine() ? [] : getEntitiesRestrictCriteria(PluginFieldsContainer::getTable(), '', '', true);
+        $entity_restrict = (isCommandLine() || !Session::getLoginUserID()) ? [] : getEntitiesRestrictCriteria(PluginFieldsContainer::getTable(), '', '', true);
         $result           = $field_container->find([
             'is_active' => 1,
             'type'      => 'dom',

--- a/inc/questiontype.class.php
+++ b/inc/questiontype.class.php
@@ -380,16 +380,14 @@ final class PluginFieldsQuestionType extends AbstractQuestionType implements For
         $field_container  = new PluginFieldsContainer();
         $available_blocks = [];
 
-        $entity_restrict = isCommandLine() ? [] : getEntitiesRestrictCriteria(PluginFieldsContainer::getTable(), '', '', true);
-
-        // If entity restriction contains an empty string value, it means no valid session
-        // is active. Running the query would produce a MySQL
-        // warning (1292: Truncated incorrect DECIMAL value)
-        foreach ($entity_restrict as $criterion) {
-            if (is_array($criterion) && in_array('', $criterion, true)) {
-                return $available_blocks;
-            }
+        // No session and not CLI: return early to avoid invalid SQL criterion from
+        // getEntitiesRestrictCriteria() (returns entities_id = '' on integer column,
+        // producing MySQL warning 1292). Consistent with the guard in setup.php.
+        if (!Session::getLoginUserID() && !isCommandLine()) {
+            return $available_blocks;
         }
+
+        $entity_restrict = isCommandLine() ? [] : getEntitiesRestrictCriteria(PluginFieldsContainer::getTable(), '', '', true);
 
         $result           = $field_container->find([
             'is_active' => 1,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43370
- Here is a brief description of what this PR does

When initializing the plugin during boot (before any user session), `getEntitiesRestrictCriteria()` was called without an active session, producing `entities_id = ''` in the SQL query and triggering a mass MySQL warning (1292: Truncated incorrect DECIMAL value).

Fix by skipping entity restriction when no user is logged in (`!Session::getLoginUserID()`), consistent with the existing check already in place in `setup.php`.

Error : 
```php
SQL: SELECT * FROM `glpi_plugin_fields_containers` WHERE `is_active` = '1' AND `type` = 'dom' AND ((`itemtypes` LIKE '%\\\"Ticket\\\"%') OR (`itemtypes` LIKE '%\\\"Change\\\"%') OR (`itemtypes` LIKE '%\\\"Problem\\\"%')) AND (`glpi_plugin_fields_containers`.`entities_id` = '') ORDER BY `name`
  Warnings: 
1292: Truncated incorrect DECIMAL value: '' at DBmysql.php line 444
  Backtrace :
  ./src/DBmysql.php:444                              
  ./src/DBmysqlIterator.php:129                      DBmysql->doQuery()
  ./src/DBmysql.php:1088                             DBmysqlIterator->execute()
  ./src/CommonDBTM.php:632                           DBmysql->request()
  ./plugins/fields/inc/questiontype.class.php:384    CommonDBTM->find()
  ./plugins/fields/inc/questiontype.class.php:426    PluginFieldsQuestionType->getAvailableBlocks()
  ./plugins/fields/setup.php:428                     PluginFieldsQuestionType::hasAvailableFields()
  ./plugins/fields/setup.php:136                     plugin_fields_register_plugin_types()
  ./src/Plugin.php:475                               plugin_init_fields()
  ./src/Plugin.php:428                               Plugin::load()
  ...tener/PostBootListener/InitializePlugins.php:75 Plugin->init()
  .../event-dispatcher/Debug/WrappedListener.php:116 Glpi\Kernel\Listener\PostBootListener\InitializePlugins->onPostBoot()
  ...ymfony/event-dispatcher/EventDispatcher.php:220 Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
  ...symfony/event-dispatcher/EventDispatcher.php:56 Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
  ...spatcher/Debug/TraceableEventDispatcher.php:142 Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
  ./src/Glpi/Kernel/Kernel.php:149                   Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
  ./vendor/symfony/http-kernel/Kernel.php:201        Glpi\Kernel\Kernel->boot()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()


```
Close https://github.com/pluginsGLPI/fields/issues/1172