### PR TITLE
Fix: table rename aborts when GenericObject migration exceeds MySQL's…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- Fix migration abort when a GenericObject container name produces a table name exceeding MySQL's 64-character limit after conversion to GlpiCustomAsset.
+
 ## [1.24.0] - 2026-04-16
 
 ### Added

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -209,8 +209,9 @@ class PluginFieldsContainer extends CommonDBTM
                 $container_class = new self();
                 foreach ($result as $container) {
                     self::generateTemplate($container);
+                    $container_name = $container['name'];
                     foreach (json_decode((string) $container['itemtypes']) as $itemtype) {
-                        $classname = self::getClassname($itemtype, $container["name"]);
+                        $classname = self::getClassname($itemtype, $container['name']);
                         // prevent usage of plugin class if not loaded
                         if (!class_exists($classname)) {
                             continue;
@@ -223,7 +224,13 @@ class PluginFieldsContainer extends CommonDBTM
                             && isset($migration_genericobject_itemtype[$itemtype])
                             && str_contains($old_table, 'glpi_plugin_fields_plugingenericobject' . $migration_genericobject_itemtype[$itemtype]['genericobject_name'])
                         ) {
-                            $new_table = str_replace('plugingenericobject' . $migration_genericobject_itemtype[$itemtype]['genericobject_name'], 'glpicustomasset' . strtolower($migration_genericobject_itemtype[$itemtype]['name']), $old_table);
+                            $new_itemtype = $migration_genericobject_itemtype[$itemtype]['itemtype'];
+                            // Limit table names to 64 chars (MySQL limit)
+                            while (strlen(getTableForItemType(self::getClassname($new_itemtype, $container_name))) > 64) {
+                                $container_name = substr((string) $container_name, 0, -1);
+                            }
+
+                            $new_table = getTableForItemType(self::getClassname($new_itemtype, $container_name));
                             $migration->renameTable($old_table, $new_table);
                         }
                     }
@@ -231,12 +238,15 @@ class PluginFieldsContainer extends CommonDBTM
                     // Update old genericobject itemtypes in container
                     $map = array_column($migration_genericobject_itemtype, 'itemtype', 'genericobject_itemtype');
                     $itemtypes = strtr($container['itemtypes'], $map);
-                    $container_class->update(
-                        [
-                            'id'         => $container['id'],
-                            'itemtypes'  => $itemtypes,
-                        ],
-                    );
+                    $update_data = [
+                        'id'        => $container['id'],
+                        'itemtypes' => $itemtypes,
+                    ];
+                    if ($container_name !== $container['name']) {
+                        $update_data['name'] = $container_name;
+                    }
+
+                    $container_class->update($update_data);
                 }
             } else {
                 throw new RuntimeException(


### PR DESCRIPTION
… 64-char limit

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43610

When migrating containers from GenericObject to GlpiCustomAsset, the plugin renames the underlying DB table. For certain object names, the new name exceeds MySQL's 64-character identifier limit, aborting the     
  migration with error 1059.                                                                                                                                                                                          
                                                                                                                                                                                                                      
  A naive table name truncation would not suffice: GLPI derives table names from class names at runtime, so the stored container name and the DB table must stay in sync. The fix truncates the container name until  
  the generated table fits within 64 chars, then persists the shortened name to the DB — mirroring an identical safeguard already present in installUserData.

## Screenshots (if appropriate):
