### PR TITLE
Fix(Core): Optimize container loading when there are a large number of entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix text area fields size and alignment
+- Optimize container loading when there are a large number of entities
 
 ## [1.24.0] - 2026-04-16
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1756,9 +1756,6 @@ HTML;
             ['type'     => $type],
         ];
 
-        $entity = $_SESSION['glpiactiveentities'] ?? 0;
-        $condition += getEntitiesRestrictCriteria('', '', $entity, true, true);
-
         if ($subtype != '') {
             if ($subtype == $itemtype . '$main') {
                 $condition[] = ['type' => 'dom'];
@@ -1777,7 +1774,7 @@ HTML;
 
         foreach ($itemtypes as $data) {
             $dataitemtypes = PluginFieldsToolbox::decodeJSONItemtypes($data['itemtypes']);
-            if (in_array($itemtype, $dataitemtypes)) {
+            if (in_array($itemtype, $dataitemtypes) && Session::haveAccessToEntity($data['entities_id'], $data['is_recursive'])) {
                 $id = $data['id'];
             }
         }
@@ -1797,9 +1794,6 @@ HTML;
     {
         $condition = ['is_active' => 1];
 
-        $entity = $_SESSION['glpiactiveentities'] ?? 0;
-        $condition += getEntitiesRestrictCriteria('', '', $entity, true, true);
-
         $container = new PluginFieldsContainer();
         $itemtypes = $container->find($condition);
 
@@ -1810,7 +1804,7 @@ HTML;
         $ids = [];
         foreach ($itemtypes as $data) {
             $dataitemtypes = PluginFieldsToolbox::decodeJSONItemtypes($data['itemtypes']);
-            if (in_array($itemtype, $dataitemtypes)) {
+            if (in_array($itemtype, $dataitemtypes) && Session::haveAccessToEntity($data['entities_id'], $data['is_recursive'])) {
                 $id = $data['id'];
                 //profiles restriction
                 if (isset($_SESSION['glpiactiveprofile']['id']) && $_SESSION['glpiactiveprofile']['id'] != null && $id > 0) {


### PR DESCRIPTION
…f entities

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #42749

A user with nearly 5,000 entities is experiencing slowness when opening a ticket containing a container.

They are using a tree view with recursive mode enabled.

Currently, the plugin adds a WHERE clause on entities using all the user’s entities (`glpi_active_entities`), which significantly impacts performance.

The logic used to verify whether access to the container is authorized has been moved further downstream in order to lighten the SQL query.

It now relies on `Session::haveAccessToEntity`.


## Screenshots (if appropriate):
