### PR TITLE
Fix size and alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased] -
+
+### Fixed
+
+- Fix text area fields size and alignment
+
 ## [1.24.0] - 2026-04-16
 
 ### Added

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -49,9 +49,9 @@
         'align_label_right': false,
     },
     'default': {
-        'field_class': 'col-12',
-        'label_class': 'col-xxl-2',
-        'input_class': 'col-xxl-10',
+        'field_class': 'col-12 col-sm-6',
+        'label_class': 'col-xxl-5',
+        'input_class': 'col-xxl-7',
         'is_horizontal': true,
         'align_label_right': true,
     },
@@ -67,7 +67,7 @@
 
 {% if not already_wrapped and not dropdown_item%}
 
-{% set class = item.isNewItem() or item is instanceof('User') or container.fields['type'] == 'dom' ? 'col-xxl-12' : 'col-xxl-9' %}
+{% set class = item.isNewItem() or item is instanceof('User') ? 'col-xxl-12' : 'col-xxl-9' %}
     <div class="col-12  {{ class }} flex-column">
         <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
             <div class="row flex-row align-items-start flex-grow-1">

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -29,12 +29,20 @@
 {% import 'components/form/fields_macros.html.twig' as macros %}
 
 {% set in_itilobject   = item is instanceof('CommonITILObject') and container.fields['type'] == 'dom' %}
+{% set in_projecttask  = item is instanceof('ProjectTask') and container.fields['type'] == 'dom' %}
 {% set in_form_builder = item is instanceof('Glpi\\Form\\Form') %}
 {% set already_wrapped = in_itilobject or in_form_builder %}
 {% set dropdown_item   = item is instanceof('CommonDropdown') and container.fields['type'] == 'dom' %}
 
 {% set textarea_display_options = {
     'in_itilobject': {
+        'field_class': 'col-12',
+        'label_class': 'col-2 col-xxl-5',
+        'input_class': 'col-10 col-xxl-7',
+        'is_horizontal': true,
+        'align_label_right': true,
+    },
+    'in_projecttask': {
         'field_class': 'col-12',
         'label_class': 'col-2',
         'input_class': 'col-10',
@@ -57,13 +65,9 @@
     },
 } %}
 
-{% if in_itilobject %}
-    {% set current_textarea_options = textarea_display_options.in_itilobject %}
-{% elseif in_form_builder %}
-    {% set current_textarea_options = textarea_display_options.in_form_builder %}
-{% else %}
-    {% set current_textarea_options = textarea_display_options.default %}
-{% endif %}
+{% set current_textarea_options = textarea_display_options[
+    in_itilobject ? 'in_itilobject' : (in_projecttask ? 'in_projecttask' : (in_form_builder ? 'in_form_builder' : 'default'))
+] %}
 
 {% if not already_wrapped and not dropdown_item%}
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43702
- Here is a brief description of what this PR does

For multi-line text fields, the alignment and size are no longer correct in the assets.

## Screenshots (if appropriate):
Before on Computer Page:
<img width="1398" height="221" alt="image" src="https://github.com/user-attachments/assets/9cf6fa12-d807-4725-9304-f8e8bb47c774" />
After :
**_Computer_**
<img width="2189" height="705" alt="image" src="https://github.com/user-attachments/assets/e8375311-215a-4445-b8d8-018b27808289" />

**_ItilObject_** 
<img width="982" height="742" alt="image" src="https://github.com/user-attachments/assets/7bc7422d-b671-4929-bc18-b94c9a55dc3c" />

**_Dropdown_**
<img width="1542" height="1037" alt="image" src="https://github.com/user-attachments/assets/ed80bf75-4ce7-4c36-aaae-cc16eb0589e4" />

**_Project task_**
<img width="3072" height="1056" alt="image" src="https://github.com/user-attachments/assets/c65f2a58-fc2c-466d-840a-734b510b1c08" />
