### PR TITLE
Adding a verification of obj value if not an array so we don't try to use push on a empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix text area fields size and alignment
 - Optimize container loading when there are a large number of entities
+- Adding a verification in refreshContainer function for obj value which can be an empty string instead of an array
 
 ## [1.24.0] - 2026-04-16
 

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -1011,7 +1011,7 @@ class PluginFieldsField extends CommonDBChild
                         var multiple_matches = item.name.match(/^(.+)\[\]$/);
                         if (multiple_matches) {
                             var name = multiple_matches[1];
-                            if (!(name in obj)) {
+                            if (!(name in obj) || obj[name] == "") {
                                 obj[name] = [];
                             }
                             obj[name].push(item.value);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ x ] I have performed a self-review of my code.

## Description

- It fixes #1155 
- Here is a brief description of what this PR does : 
It checks the value of the item that has multiple matches in obj to see if it's an empty string instead of an empty array (this can happen when a multi-value field is checked) in which case it's replaced by an empty array so the code doesn't bug when trying to push a value to a string.