### PR TITLE
Fix - Convert empty dropdown value (-1) to null on form submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix empty dropdown value (-1) on form submission
 - Fix text area fields size and alignment
 - Optimize container loading when there are a large number of entities
 

--- a/inc/destinationfield.class.php
+++ b/inc/destinationfield.class.php
@@ -135,7 +135,8 @@ class PluginFieldsDestinationField extends AbstractConfigField
                     $input[sprintf('itemtype_%s', $field_name)] = $answer->getRawAnswer()['itemtype'];
                     $input[sprintf('items_id_%s', $field_name)] = $answer->getRawAnswer()['items_id'];
                 } elseif ($field->fields['type'] == 'dropdown') {
-                    $input[$field_name] = $answer->getRawAnswer()['items_id'];
+                    $raw_id = $answer->getRawAnswer()['items_id'];
+                    $input[$field_name] = ($raw_id > 0) ? $raw_id : null;
                 } else {
                     $input[$field_name] = $value ?? $answer->getRawAnswer();
                 }

--- a/inc/destinationfield.class.php
+++ b/inc/destinationfield.class.php
@@ -135,7 +135,7 @@ class PluginFieldsDestinationField extends AbstractConfigField
                     $input[sprintf('itemtype_%s', $field_name)] = $answer->getRawAnswer()['itemtype'];
                     $input[sprintf('items_id_%s', $field_name)] = $answer->getRawAnswer()['items_id'];
                 } elseif ($field->fields['type'] == 'dropdown') {
-                    $raw_id = $answer->getRawAnswer()['items_id'];
+                    $raw_id = (int) $answer->getRawAnswer()['items_id'];
                     $input[$field_name] = ($raw_id > 0) ? $raw_id : null;
                 } else {
                     $input[$field_name] = $value ?? $answer->getRawAnswer();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43956
- Here is a brief description of what this PR does

When a form containing a Fields dropdown question (either via `PluginFieldsQuestionType` or the native `QuestionTypeItemDropdown`) is submitted without a value selected, GLPI sends `-1` (or `0`) as the `items_id`. This value was passed as-is to the INSERT query, but the underlying column is `INT UNSIGNED`, causing a MySQL "Out of range value" error and preventing ticket creation.

```php
[2026-05-12 08:04:50] glpi.ERROR:   *** An error occured during the form `Test` submission: MySQL query error: Out of range value for column 'plugin_fields_dropdownfielddropdowns_id' at row 1 (1264) in SQL query "INSERT INTO `glpi_plugin_fields_tickettestblocs` (`plugin_fields_containers_id`, `plugin_fields_dropdownfielddropdowns_id`, `itemtype`, `items_id`, `entities_id`) VALUES ('2', '-1', 'Ticket', '8', '0')".
  Backtrace :
  ./src/DBmysql.php:416                              
  ./src/DBmysql.php:1377                             DBmysql->doQuery()
  ./src/CommonDBTM.php:778                           DBmysql->insert()
  ./src/CommonDBTM.php:1382                          CommonDBTM->addToDB()
  ./plugins/fields/inc/container.class.php:1430      CommonDBTM->add()
  ./plugins/fields/inc/container.class.php:1839      PluginFieldsContainer->updateFieldsValues()
  ./src/Plugin.php:1810                              PluginFieldsContainer::postItemAdd()
  ./src/CommonDBTM.php:1432                          Plugin::doHook()
  ...ation/AbstractCommonITILFormDestination.php:205 CommonDBTM->add()
  ./src/Session.php:2457                             Glpi\Form\Destination\AbstractCommonITILFormDestination->{closure:Glpi\Form\Destination\AbstractCommonITILFormDestination::createDestinationItems():205}()
  ...ation/AbstractCommonITILFormDestination.php:205 Session::callAsSystem()
  ...Glpi/Form/AnswersHandler/AnswersHandler.php:435 Glpi\Form\Destination\AbstractCommonITILFormDestination->createDestinationItems()
  ...Glpi/Form/AnswersHandler/AnswersHandler.php:288 Glpi\Form\AnswersHandler\AnswersHandler->createDestinations()
  ...Glpi/Form/AnswersHandler/AnswersHandler.php:206 Glpi\Form\AnswersHandler\AnswersHandler->doSaveAnswers()
  .../Controller/Form/SubmitAnswerController.php:156 Glpi\Form\AnswersHandler\AnswersHandler->saveAnswers()
  ...i/Controller/Form/SubmitAnswerController.php:83 Glpi\Controller\Form\SubmitAnswerController->saveSubmittedAnswers()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\Form\SubmitAnswerController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```

**Fix:** In `applyConfiguratedValueToInputUsingAnswers()`, any `items_id ≤ 0` is now converted to `null` before being added to the input, consistent with how GLPI core handles this (see `EntityFieldStrategy`).