### PR TITLE
fix: nested array stored in DB for readonly dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix nested array stored in DB for readonly dropdown
 - Fix migration abort when a GenericObject container name produces a table name exceeding MySQL's 64-character limit after conversion to GlpiCustomAsset.
 - Fix empty dropdown value (-1) on form submission
 - Fix text area fields size and alignment

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1413,11 +1413,12 @@ HTML;
                     // Add new values to existing ones
                     $existing_values = json_decode($obj->fields[$field_name] ?? '[]', true);
                     $new_values      = is_array($data[$field_name]) ? $data[$field_name] : [$data[$field_name]];
+                    $new_values      = $this->flattenScalars($new_values);
                     $data[$field_name] = json_encode(array_values(array_unique(array_merge($existing_values, $new_values))));
 
                 } else {
                     $value = $data[$field_name];
-                    $value = is_array($value) ? $value : [];
+                    $value = is_array($value) ? $this->flattenScalars($value) : [];
                     $data[$field_name] = json_encode($value);
                 }
             } elseif (array_key_exists('_' . $field_name . '_defined', $data)) {
@@ -1964,6 +1965,29 @@ HTML;
         }
 
         return false;
+    }
+
+    /**
+     * Flatten a one-level-deep array of mixed scalars/arrays into a flat array of scalars.
+     * Guards against nested arrays produced when a readonly multiple-dropdown field submits
+     * with a doubly-bracketed name (e.g. foo[][][]).
+     */
+    private function flattenScalars(array $values): array
+    {
+        $flat = [];
+        foreach ($values as $v) {
+            if (is_array($v)) {
+                foreach ($v as $inner) {
+                    if (is_scalar($inner)) {
+                        $flat[] = $inner;
+                    }
+                }
+            } elseif (is_scalar($v)) {
+                $flat[] = $v;
+            }
+        }
+
+        return $flat;
     }
 
     /**

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1969,25 +1969,18 @@ HTML;
 
     /**
      * Flatten a one-level-deep array of mixed scalars/arrays into a flat array of scalars.
-     * Guards against nested arrays produced when a readonly multiple-dropdown field submits
-     * with a doubly-bracketed name (e.g. foo[][][]).
+     *
+     * @param array<mixed, mixed> $values
+     * @return array<mixed, mixed> $values the flattened array with only scalar values
      */
     private function flattenScalars(array $values): array
     {
         $flat = [];
         foreach ($values as $v) {
-            if (is_array($v)) {
-                foreach ($v as $inner) {
-                    if (is_scalar($inner)) {
-                        $flat[] = $inner;
-                    }
-                }
-            } elseif (is_scalar($v)) {
-                $flat[] = $v;
-            }
+            array_push($flat, ...(is_array($v) ? $v : [$v]));
         }
 
-        return $flat;
+        return array_values(array_filter($flat, is_scalar(...)));
     }
 
     /**

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -1283,6 +1283,18 @@ JAVASCRIPT,
                 $value = is_array($decoded) ? $decoded : [];
             }
 
+            if ($field['multiple'] && is_array($value)) {
+                // Flatten any nested arrays caused by corrupted DB data (double-encoded values)
+                // so that Dropdown::show() always receives a flat list of scalars.
+                $value = array_values(array_filter(
+                    array_merge(...array_map(
+                        static fn($v) => is_array($v) ? array_values($v) : [$v],
+                        $value,
+                    )),
+                    is_scalar(...),
+                ));
+            }
+
             $field['value'] = $value;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.

## Description

- It fixes ticket !44062.

- Steps to reproduce:
  - Create a container with at least two multiple-dropdown custom fields : one set as readonly and one editable.
  - Open an item that has a value saved for the readonly dropdown (e.g. ["3"]).
  - Change the value of the editable dropdown and save the form.
  - Reload the page : a PHP error is thrown.
  
- Root cause:
  - The `dropdownField` Twig macro pre-appends `[]` to the field name for all multiple inputs (e.g. `plugin_fields_donefielddropdowns_id[]`). 
  - For readonly fields, `Dropdown::show()` renders hidden inputs and appends another `[]`, producing `plugin_fields_donefielddropdowns_id[][]`. 
  - When the form is saved, PHP parses this double-bracketed name as a nested array (`[['3']]` instead of `['3']`), which gets JSON-encoded as `[["3"]]` and stored corrupted in the database. 
  - On the next page load, `Dropdown::show()` receives the decoded nested array, iterates over it, and tries to use an array as an array key inside isset(), triggering a PHP 8 TypeError.
  
- Fix:
  - Before json_encode-ing a multiple field value for storage, `flattenScalars()` collapses any nested arrays into a flat list of scalars, preventing the corruption from ever reaching the database.
  - The same flattening is applied at display time so that values already corrupted in the database before this fix are handled.
