### PR TITLE
fix(migration): ensure GenericObject type dropdowns are migrated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix text area fields size and alignment
 - Optimize container loading when there are a large number of entities
 - Adding a verification in refreshContainer function for obj value which can be an empty string instead of an array
+- Fix GenericObject type dropdowns migration
 
 ## [1.24.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Adding a verification in refreshContainer function for obj value which can be an empty string instead of an array
 - Fix refreshContainer crash when a field is serialized both as a scalar and as an array
 - Centralized label preparation and system name generation.
+- Fix GenericObject type dropdowns migration
 
 ## [1.24.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix search crash when two containers share a dropdown field with the same name.
 - Fix handle native GLPI dropdown types when binding additional fields to form destination
 - Fix container name/label corruption during GenericObject migration, which could break the migration with a MySQL identifier-length error.
+- Fix GenericObject type dropdowns migration
 
 ## [1.24.2] - 2026-06-30
 
@@ -35,7 +36,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Adding a verification in refreshContainer function for obj value which can be an empty string instead of an array
 - Fix refreshContainer crash when a field is serialized both as a scalar and as an array
 - Centralized label preparation and system name generation.
-- Fix GenericObject type dropdowns migration
 
 ## [1.24.0] - 2026-04-16
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -163,38 +163,7 @@ class PluginFieldsContainer extends CommonDBTM
 
             // Get itemtypes from PluginGenericobject
             if ($DB->tableExists('glpi_plugin_genericobject_types')) {
-                // Check GenericObject version
-                $genericobject_info = Plugin::getInfo('genericobject');
-                if (version_compare($genericobject_info['version'] ?? '0', '3.0.0', '<')) {
-                    throw new RuntimeException(
-                        'GenericObject plugin cannot be migrated. Please update it to the latest version.',
-                    );
-                }
-
-                // Check glpi_plugin_genericobject_types table
-                if (!$DB->fieldExists('glpi_plugin_genericobject_types', 'itemtype')) {
-                    throw new RuntimeException(
-                        'Integrity error on the glpi_plugin_genericobject_types table from the GenericObject plugin.',
-                    );
-                }
-
-                $migration_genericobject_itemtype = [];
-                $result = $DB->request(['FROM' => 'glpi_plugin_genericobject_types']);
-                foreach ($result as $type) {
-                    $customasset_classname = 'Glpi\\\\CustomAsset\\\\' . $type['name'] . 'Asset';
-                    if (str_ends_with((string) $type['itemtype'], 'Model')) {
-                        $customasset_classname = 'Glpi\\\\CustomAsset\\\\' . $type['name'] . 'AssetModel';
-                    } elseif (str_ends_with((string) $type['itemtype'], 'Type')) {
-                        $customasset_classname = 'Glpi\\\\CustomAsset\\\\' . $type['name'] . 'AssetType';
-                    }
-
-                    $migration_genericobject_itemtype[$type['itemtype']] = [
-                        'genericobject_itemtype' => $type['itemtype'],
-                        'itemtype' => $customasset_classname,
-                        'genericobject_name' => $type['name'],
-                        'name' => $type['name'] . 'Asset',
-                    ];
-                }
+                $migration_genericobject_itemtype = PluginFieldsMigration::getGenericObjectTypes();
 
                 // Get containers with PluginGenericobject itemtype
                 $result = $DB->request([

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -28,6 +28,7 @@
  * -------------------------------------------------------------------------
  */
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Asset\AssetDefinitionManager;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Features\Clonable;
 use Glpi\Form\Question;
@@ -151,6 +152,45 @@ class PluginFieldsField extends CommonDBChild
         if (Config::getConfigurationValue('plugin:fields', 'stable_search_options') !== 'yes') {
             self::migrateToStableSO($migration);
             $migration->addConfig(['stable_search_options' => 'yes'], 'plugin:fields');
+        }
+
+        /* Update old genericobject_itemtype dropdown fields to customasset_itemtype dropdown fields */
+
+        // Get all types from PluginGenericobject
+        $migration_genericobject_itemtypes = PluginFieldsMigration::getGenericObjectTypes();
+
+        foreach($migration_genericobject_itemtypes as $type) {
+            // Check if genericobject and customasset itemtypes exist
+            if (!class_exists($type['genericobject_itemtype'])) {
+                $migration->addDebugMessage(sprintf(
+                    'The itemtype %s does not exist, please check if %s.class.php is present',
+                    $type['genericobject_itemtype'],
+                    $type['genericobject_name'],
+                ));
+                continue;
+            }
+            $itemtype = str_replace('\\\\', '\\', $type['itemtype']);
+            if (!class_exists($itemtype)) {
+                $migration->addDebugMessage(sprintf(
+                    'The itemtype %s does not exist, please check if %s.class.php is present',
+                    $itemtype,
+                    $type['name'],
+                ));
+                continue;
+            }
+
+            // If corresponding customasset_itemtype exists, update field type
+            $migration->addPostQuery(
+                $DB->buildUpdate(
+                    self::getTable(),
+                    [
+                        'type' => 'dropdown-' . $itemtype,
+                    ],
+                    [
+                        'type' => ['LIKE', 'dropdown-' . $type['genericobject_itemtype'] . '%'],
+                    ],
+                ),
+            );
         }
 
         return true;

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -28,7 +28,6 @@
  * -------------------------------------------------------------------------
  */
 use Glpi\Application\View\TemplateRenderer;
-use Glpi\Asset\AssetDefinitionManager;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Features\Clonable;
 use Glpi\Form\Question;
@@ -154,43 +153,45 @@ class PluginFieldsField extends CommonDBChild
             $migration->addConfig(['stable_search_options' => 'yes'], 'plugin:fields');
         }
 
-        /* Update old genericobject_itemtype dropdown fields to customasset_itemtype dropdown fields */
+        // Update old genericobject_itemtype dropdown fields to customasset_itemtype dropdown fields
+        if ($DB->tableExists('glpi_plugin_genericobject_types')) {
+            // Get all types from PluginGenericobject
+            $migration_genericobject_itemtypes = PluginFieldsMigration::getGenericObjectTypes();
 
-        // Get all types from PluginGenericobject
-        $migration_genericobject_itemtypes = PluginFieldsMigration::getGenericObjectTypes();
+            foreach ($migration_genericobject_itemtypes as $type) {
+                // Check if genericobject and customasset itemtypes exist
+                if (!class_exists($type['genericobject_itemtype'])) {
+                    $migration->addDebugMessage(sprintf(
+                        'The itemtype %s does not exist, please check if %s.class.php is present',
+                        $type['genericobject_itemtype'],
+                        $type['genericobject_name'],
+                    ));
+                    continue;
+                }
 
-        foreach($migration_genericobject_itemtypes as $type) {
-            // Check if genericobject and customasset itemtypes exist
-            if (!class_exists($type['genericobject_itemtype'])) {
-                $migration->addDebugMessage(sprintf(
-                    'The itemtype %s does not exist, please check if %s.class.php is present',
-                    $type['genericobject_itemtype'],
-                    $type['genericobject_name'],
-                ));
-                continue;
+                $itemtype = str_replace('\\\\', '\\', $type['itemtype']);
+                if (!class_exists($itemtype)) {
+                    $migration->addDebugMessage(sprintf(
+                        'The itemtype %s does not exist, please check if %s.class.php is present',
+                        $itemtype,
+                        $type['name'],
+                    ));
+                    continue;
+                }
+
+                // If corresponding customasset_itemtype exists, update field type
+                $migration->addPostQuery(
+                    $DB->buildUpdate(
+                        self::getTable(),
+                        [
+                            'type' => 'dropdown-' . $itemtype,
+                        ],
+                        [
+                            'type' => ['LIKE', 'dropdown-' . $type['genericobject_itemtype'] . '%'],
+                        ],
+                    ),
+                );
             }
-            $itemtype = str_replace('\\\\', '\\', $type['itemtype']);
-            if (!class_exists($itemtype)) {
-                $migration->addDebugMessage(sprintf(
-                    'The itemtype %s does not exist, please check if %s.class.php is present',
-                    $itemtype,
-                    $type['name'],
-                ));
-                continue;
-            }
-
-            // If corresponding customasset_itemtype exists, update field type
-            $migration->addPostQuery(
-                $DB->buildUpdate(
-                    self::getTable(),
-                    [
-                        'type' => 'dropdown-' . $itemtype,
-                    ],
-                    [
-                        'type' => ['LIKE', 'dropdown-' . $type['genericobject_itemtype'] . '%'],
-                    ],
-                ),
-            );
         }
 
         return true;

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -159,16 +159,6 @@ class PluginFieldsField extends CommonDBChild
             $migration_genericobject_itemtypes = PluginFieldsMigration::getGenericObjectTypes();
 
             foreach ($migration_genericobject_itemtypes as $type) {
-                // Check if genericobject and customasset itemtypes exist
-                if (!class_exists($type['genericobject_itemtype'])) {
-                    $migration->addDebugMessage(sprintf(
-                        'The itemtype %s does not exist, please check if %s.class.php is present',
-                        $type['genericobject_itemtype'],
-                        $type['genericobject_name'],
-                    ));
-                    continue;
-                }
-
                 $itemtype = str_replace('\\\\', '\\', $type['itemtype']);
                 if (!class_exists($itemtype)) {
                     $migration->addDebugMessage(sprintf(

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -187,7 +187,7 @@ class PluginFieldsField extends CommonDBChild
                             'type' => 'dropdown-' . $itemtype,
                         ],
                         [
-                            'type' => ['LIKE', 'dropdown-' . $type['genericobject_itemtype'] . '%'],
+                            'type' => ['LIKE', 'dropdown-' . $type['genericobject_itemtype']],
                         ],
                     ),
                 );

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -154,7 +154,14 @@ class PluginFieldsField extends CommonDBChild
         }
 
         // Update old genericobject_itemtype dropdown fields to customasset_itemtype dropdown fields
-        if ($DB->tableExists('glpi_plugin_genericobject_types')) {
+        // Update old genericobject_itemtype dropdown fields to customasset_itemtype dropdown fields
+        $has_genericobject_fields = $DB->tableExists('glpi_plugin_genericobject_types')
+            && $DB->request([
+                'COUNT' => 'id',
+                'FROM'  => self::getTable(),
+                'WHERE' => ['type' => ['LIKE', 'dropdown-PluginGenericobject%']],
+            ])->current()['COUNT(id)'] > 0;
+        if ($has_genericobject_fields) {
             // Get all types from PluginGenericobject
             $migration_genericobject_itemtypes = PluginFieldsMigration::getGenericObjectTypes();
 

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -154,7 +154,6 @@ class PluginFieldsField extends CommonDBChild
         }
 
         // Update old genericobject_itemtype dropdown fields to customasset_itemtype dropdown fields
-        // Update old genericobject_itemtype dropdown fields to customasset_itemtype dropdown fields
         $has_genericobject_fields = $DB->tableExists('glpi_plugin_genericobject_types')
             && $DB->request([
                 'COUNT' => 'id',

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -200,4 +200,44 @@ class PluginFieldsMigration extends Migration
             fn(string $field) => !in_array($field, $basic_fields, true),
         );
     }
+
+    public static function getGenericObjectTypes() {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        // Check GenericObject version
+        $genericobject_info = Plugin::getInfo('genericobject');
+        if (version_compare($genericobject_info['version'] ?? '0', '3.0.0', '<')) {
+            throw new RuntimeException(
+                'GenericObject plugin cannot be migrated. Please update it to the latest version.',
+            );
+        }
+
+        // Check glpi_plugin_genericobject_types table
+        if (!$DB->fieldExists('glpi_plugin_genericobject_types', 'itemtype')) {
+            throw new RuntimeException(
+                'Integrity error on the glpi_plugin_genericobject_types table from the GenericObject plugin.',
+            );
+        }
+
+        $migration_genericobject_itemtype = [];
+        $result = $DB->request(['FROM' => 'glpi_plugin_genericobject_types']);
+        foreach ($result as $type) {
+            $customasset_classname = 'Glpi\\\\CustomAsset\\\\' . $type['name'] . 'Asset';
+            if (str_ends_with((string) $type['itemtype'], 'Model')) {
+                $customasset_classname = 'Glpi\\\\CustomAsset\\\\' . $type['name'] . 'AssetModel';
+            } elseif (str_ends_with((string) $type['itemtype'], 'Type')) {
+                $customasset_classname = 'Glpi\\\\CustomAsset\\\\' . $type['name'] . 'AssetType';
+            }
+
+            $migration_genericobject_itemtype[$type['itemtype']] = [
+                'genericobject_itemtype' => $type['itemtype'],
+                'itemtype' => $customasset_classname,
+                'genericobject_name' => $type['name'],
+                'name' => $type['name'] . 'Asset',
+            ];
+        }
+
+        return $migration_genericobject_itemtype;
+    }
 }

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -201,7 +201,7 @@ class PluginFieldsMigration extends Migration
         );
     }
 
-    public static function getGenericObjectTypes()
+    public static function getGenericObjectTypes(): array
     {
         /** @var DBmysql $DB */
         global $DB;

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -201,7 +201,8 @@ class PluginFieldsMigration extends Migration
         );
     }
 
-    public static function getGenericObjectTypes() {
+    public static function getGenericObjectTypes()
+    {
         /** @var DBmysql $DB */
         global $DB;
 


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #42658
- Here is a brief description of what this PR does
The dropdown menus from an old GenericObject asset were not migrated correctly and caused a Twig error when the Fields block was displayed

<img width="1977" height="428" alt="image" src="https://github.com/user-attachments/assets/4897cebe-d1fa-4718-99e8-d4c7b90391bf" />


## Screenshots (if appropriate):

Old GenericObject type dropdown fields:
<img width="986" height="155" alt="image" src="https://github.com/user-attachments/assets/e1108acb-a50b-49c0-aa7a-12b587fdaeb2" />

<img width="2110" height="168" alt="image" src="https://github.com/user-attachments/assets/0a2ed1f1-12e7-4059-8c37-182c5354f2df" />
