### PR TITLE
fix(destinationfield): prevent stale value leak across form answers

### DIFF
--- a/inc/destinationfield.class.php
+++ b/inc/destinationfield.class.php
@@ -138,7 +138,7 @@ class PluginFieldsDestinationField extends AbstractConfigField
                     $raw_id = (int) $answer->getRawAnswer()['items_id'];
                     $input[$field_name] = ($raw_id > 0) ? $raw_id : null;
                 } else {
-                    $input[$field_name] = $value ?? $answer->getRawAnswer();
+                    $input[$field_name] = $answer->getRawAnswer();
                 }
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.

## Description

- Fixes #1201
- In `PluginFieldsDestinationField::applyConfiguratedValueToInputUsingAnswers()`,
  `$value` is assigned only inside the `QuestionTypeItemDropdown` branch and is
  never reset between iterations of the `foreach ($answers as $answer)` loop.
  On a later iteration targeting a non-dropdown field (`number`, `text`,
  `textarea`, `richtext`, `url`, `date`, `datetime`), the expression
  `$value ?? $answer->getRawAnswer()` returned the stale `$value` from the
  previous iteration, silently overwriting the user's typed value with the
  `items_id` of the earlier item-dropdown answer.
- `$value` has no meaning outside the `QuestionTypeItemDropdown` branch (the
  `glpi_item` / `dropdown` branches read `items_id` directly from the current
  answer), so the fall-through `else` must always read from the current answer:

  ```diff
  - $input[$field_name] = $value ?? $answer->getRawAnswer();
  + $input[$field_name] = $answer->getRawAnswer();
  ```

- Single-line change in inc/destinationfield.class.php. No behavior change
for QuestionTypeItemDropdown, glpi_item or dropdown target field types.
- Reproduction and root cause analysis are detailed in #1201.

