### PR TITLE
fix(js): prevent refreshContainer crash when fields dropdown values mix scalar and array inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix text area fields size and alignment
 - Optimize container loading when there are a large number of entities
 - Adding a verification in refreshContainer function for obj value which can be an empty string instead of an array
+- Fix refreshContainer crash when a field is serialized both as a scalar and as an array
 
 ## [1.24.0] - 2026-04-16
 

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -1013,6 +1013,8 @@ class PluginFieldsField extends CommonDBChild
                             var name = multiple_matches[1];
                             if (!(name in obj) || obj[name] == "") {
                                 obj[name] = [];
+                            } else if (!Array.isArray(obj[name])) {
+                                obj[name] = [obj[name]];
                             }
                             obj[name].push(item.value);
                         } else {


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44474
- This PR fixes a JavaScript crash in the Fields plugin when `refreshContainer()` serializes a form containing both a scalar field name and an array field name for the same base key. This was causing the dropdown to stay open even after selecting a new value.

<img width="1309" height="881" alt="Capture d’écran du 2026-06-04 16-08-32" src="https://github.com/user-attachments/assets/d090bb97-2d9d-430f-b28e-7ff3e601c3d2" />

<img width="360" height="290" alt="Capture d’écran du 2026-06-05 09-10-27" src="https://github.com/user-attachments/assets/1af70e78-7bc3-4ad2-835b-2bb801e4d9ec" />


