### PR TITLE
FIX / (Rector) cast $value to string in preg_match_all call

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1145,7 +1145,7 @@ HTML;
                     // For delete <sup class='tab_nb'>number</sup> :
                     foreach ($tabs as &$value) {
                         $results = [];
-                        if (preg_match_all('#<sup.*>(.+)</sup>#', $value, $results)) {
+                        if (preg_match_all('#<sup.*>(.+)</sup>#', (string) $value, $results)) {
                             $value = str_replace($results[0][0], '', $value);
                         }
                     }


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

 - Rector was flagging a CI error because the `preg_match_all` argument `$value` could be of several types, so a `(string) `cast was added to ensure strict type compliance.