### PR TITLE
fix(container.class.php): fix the name of dropdown fields in log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix the name of dropdown fields in logs when updating an item
 - Fix plugin configuration deletion during uninstallation
 - Fix nested array stored in DB for readonly dropdown
 - Fix migration abort when a GenericObject container name produces a table name exceeding MySQL's 64-character limit after conversion to GlpiCustomAsset.

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1594,7 +1594,7 @@ HTML;
             //for all change find searchoption
             foreach ($updates as $key => $changes) {
                 foreach ($searchoptions as $id_search_option => $searchoption) {
-                    if ($searchoption['field'] == $key) {
+                    if ($searchoption['field'] == $key || $searchoption['linkfield'] == $key) {
                         $changes[0] = $id_search_option;
 
                         if ($searchoption['datatype'] === 'dropdown') {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.

## Description

- It fixes !44835
- Before this fix, the name of dropdown fields was missing in logs.
- For dropdown fields (both custom and `dropdown-<ItemType>`), the search option sets: 
  - `field` → `completename` or `name` (from the foreign table, e.g. `glpi_users.name`)
  - `linkfield` → the actual column in the container table (e.g. `usersfield_0`)
- So, the current code compares `name` against the actual DB column key when updating = it never matches -> the name of the field doesn't appear.
- fix: add `$searchoption['linkfield'] == $key` to check the the actual column in the container table.
