### PR TITLE
1.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED]
+## [1.24.1] - 2026-06-24
 
 ### Fixed
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,6 +99,11 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
    </authors>
    <versions>
       <version>
+         <num>1.24.1</num>
+         <compatibility>~11.0.2</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.24.1/glpi-fields-1.24.1.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.24.0</num>
          <compatibility>~11.0.2</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.24.0/glpi-fields-1.24.0.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 /** @var array $CFG_GLPI */
 global $CFG_GLPI;
 
-define('PLUGIN_FIELDS_VERSION', '1.24.0');
+define('PLUGIN_FIELDS_VERSION', '1.24.1');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_FIELDS_MIN_GLPI', '11.0.2');


### PR DESCRIPTION
## [1.24.1] - 2026-06-24

### Fixed

- Fix the name of dropdown fields in logs when updating an item
- Fix plugin configuration deletion during uninstallation
- Fix nested array stored in DB for readonly dropdown
- Fix migration abort when a GenericObject container name produces a table name exceeding MySQL's 64-character limit after conversion to GlpiCustomAsset.
- Fix empty dropdown value (-1) on form submission
- Fix text area fields size and alignment
- Optimize container loading when there are a large number of entities
- Adding a verification in refreshContainer function for obj value which can be an empty string instead of an array
- Fix refreshContainer crash when a field is serialized both as a scalar and as an array
- Centralized label preparation and system name generation.