### PR TITLE
fix: apply translation to container tab name in getTabNameForItem

### DIFF
--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1337,7 +1337,7 @@ HTML;
                         if (!$item->isEntityAssign() || in_array($item->fields['entities_id'], $entities)) {
                             $display_condition = new PluginFieldsContainerDisplayCondition();
                             if ($display_condition->computeDisplayContainer($item, $data['id'])) {
-                                $tabs_entries[$data['id']] = self::createTabEntry($data['label'], 0, null, PluginFieldsContainer::getIcon());
+                                $tabs_entries[$data['id']] = self::createTabEntry(PluginFieldsLabelTranslation::getLabelFor(array_merge($data, ['itemtype' => 'PluginFieldsContainer'])), 0, null, PluginFieldsContainer::getIcon());
                             }
                         }
                     }


### PR DESCRIPTION
Container tab names were displayed using \$data['label'] directly without going through the translation system. This fix applies getLabelFor() to correctly display translated tab labels based on the user's language.

Fixes tab name translation not working when language is set to non-default.