### PR TITLE
Fix: make associated item type required in container form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Make "Associated item type" mandatory when creating a container.
+
 ## [1.24.1] - 2026-06-24
 
 ### Fixed

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -653,7 +653,7 @@ class PluginFieldsContainer extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-        if (!isset($input['itemtypes'])) {
+        if (empty($input['itemtypes'])) {
             Session::AddMessageAfterRedirect(
                 __(
                     'You cannot add block without associated element type',
@@ -1101,6 +1101,7 @@ HTML;
                 'multiple'            => !$is_domtab,
                 'width'               => 200,
                 'display_emptychoice' => $is_domtab,
+                'required'            => true,
             ],
         );
 

--- a/tests/Units/ContainerTest.php
+++ b/tests/Units/ContainerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Fields plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Fields.
+ *
+ * Fields is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Fields is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fields. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2013-2023 by Fields plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/fields
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Field\Tests\Units;
+
+use Computer;
+use Glpi\Tests\DbTestCase;
+use GlpiPlugin\Field\Tests\FieldTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PluginFieldsContainer;
+
+require_once __DIR__ . '/../FieldTestCase.php';
+
+final class ContainerTest extends DbTestCase
+{
+    use FieldTestTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->login();
+    }
+
+    public function tearDown(): void
+    {
+        $this->tearDownFieldTest();
+        parent::tearDown();
+    }
+
+    public static function provideInvalidItemtypes(): iterable
+    {
+        yield 'missing itemtypes' => [
+            'input' => [
+                'name'  => 'test_container',
+                'label' => 'Test Container',
+                'type'  => 'tab',
+            ],
+        ];
+
+        yield 'empty itemtypes array' => [
+            'input' => [
+                'name'      => 'test_container',
+                'label'     => 'Test Container',
+                'type'      => 'tab',
+                'itemtypes' => [],
+            ],
+        ];
+
+        yield 'empty itemtypes string' => [
+            'input' => [
+                'name'      => 'test_container',
+                'label'     => 'Test Container',
+                'type'      => 'tab',
+                'itemtypes' => '',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideInvalidItemtypes')]
+    public function testAddWithoutItemtypesIsRejected(array $input): void
+    {
+        $container = new PluginFieldsContainer();
+        $result = $container->add($input);
+
+        $this->assertFalse($result);
+    }
+
+    public function testAddWithValidItemtypesSucceeds(): void
+    {
+        $container = $this->createFieldContainer([
+            'label'        => 'ValidItemtypes ' . $this->getUniqueString(),
+            'type'         => 'tab',
+            'itemtypes'    => [Computer::class],
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $this->assertGreaterThan(0, $container->getID());
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45044

The "Associated item type" field is now required when creating a container.
The HTML select receives the `required` attribute so the browser blocks submission when nothing is selected.
The server-side guard in `prepareInputForAdd` now uses `empty()` instead of `!isset()` to also reject an explicitly empty array.

## Screenshots (if appropriate):
