### PR TITLE
Fix(Migration): prevent container name corruption on partial update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix search crash when two containers share a dropdown field with the same name.
+- Prevent table and file regeneration when label and/or name is updated.
 
 ## [1.24.2] - 2026-06-30
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -648,8 +648,10 @@ class PluginFieldsContainer extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
-        unset($input['label']);
-        unset($input['name']);
+        if (isAPI() || isset($input['form_submission']) ) {
+            unset($input['label']);
+            unset($input['name']);
+        }
 
         return $input;
     }
@@ -973,17 +975,24 @@ HTML;
         echo '<tr>';
         echo "<td width='20%'>" . __('Label') . ' : </td>';
         echo "<td width='30%'>";
-        $options = [
+        $label_options = [
             'value' => $this->fields['label'],
         ];
 
         if (!$this->isNewID($ID)) {
-            $options['readonly'] = true;
+            $label_options['readonly'] = true;
         }
 
         echo Html::input(
             'label',
-            $options,
+            $label_options,
+        );
+
+        echo Html::hidden(
+            'form_submission',
+            [
+                'value' => true,
+            ],
         );
         echo '</td>';
         echo "<td width='20%'>&nbsp;</td>";

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -648,7 +648,10 @@ class PluginFieldsContainer extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
-        return PluginFieldsToolbox::prepareLabel($input);
+        unset($input['label']);
+        unset($input['name']);
+
+        return $input;
     }
 
     public function prepareInputForAdd($input)
@@ -970,11 +973,17 @@ HTML;
         echo '<tr>';
         echo "<td width='20%'>" . __('Label') . ' : </td>';
         echo "<td width='30%'>";
+        $options = [
+            'value' => $this->fields['label'],
+        ];
+
+        if (!$this->isNewID($ID)) {
+            $options['readonly'] = true;
+        }
+
         echo Html::input(
             'label',
-            [
-                'value' => $this->fields['label'],
-            ],
+            $options,
         );
         echo '</td>';
         echo "<td width='20%'>&nbsp;</td>";

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -648,7 +648,7 @@ class PluginFieldsContainer extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
-        if (isAPI() || isset($input['form_submission']) ) {
+        if (isAPI() || isset($input['form_submission'])) {
             unset($input['label']);
             unset($input['name']);
         }

--- a/tests/Units/ContainerTest.php
+++ b/tests/Units/ContainerTest.php
@@ -36,7 +36,6 @@ use Glpi\Tests\GLPITestCase;
 use GlpiPlugin\Field\Tests\FieldTestTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PluginFieldsContainer;
-use Ticket;
 
 require_once __DIR__ . '/../FieldTestCase.php';
 
@@ -152,7 +151,7 @@ final class ContainerTest extends DbTestCase
         ]);
 
         $original_name = $container->fields['name'];
-        $new_name = 'mig_' . substr($original_name, 0, 20);
+        $new_name = 'mig_' . substr((string) $original_name, 0, 20);
 
         $container->update(['id' => $container->getID(), 'name' => $new_name]);
 

--- a/tests/Units/ContainerTest.php
+++ b/tests/Units/ContainerTest.php
@@ -36,6 +36,7 @@ use Glpi\Tests\GLPITestCase;
 use GlpiPlugin\Field\Tests\FieldTestTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PluginFieldsContainer;
+use Ticket;
 
 require_once __DIR__ . '/../FieldTestCase.php';
 
@@ -105,5 +106,57 @@ final class ContainerTest extends DbTestCase
         ]);
 
         $this->assertGreaterThan(0, $container->getID());
+    }
+
+    public function testPrepareInputForUpdateStripsLabelAndNameOnFormSubmission(): void
+    {
+        $container = new PluginFieldsContainer();
+        $input = [
+            'label'           => 'New Label',
+            'name'            => 'new_name',
+            'form_submission' => true,
+            'is_active'       => 1,
+        ];
+
+        $result = $container->prepareInputForUpdate($input);
+
+        $this->assertArrayNotHasKey('label', $result);
+        $this->assertArrayNotHasKey('name', $result);
+        $this->assertArrayHasKey('is_active', $result);
+    }
+
+    public function testPrepareInputForUpdatePreservesNameAndLabelForMigration(): void
+    {
+        $container = new PluginFieldsContainer();
+        $input = [
+            'name'      => 'migration_corrected_name',
+            'label'     => 'Some Label',
+            'itemtypes' => '["Computer"]',
+        ];
+
+        $result = $container->prepareInputForUpdate($input);
+
+        $this->assertSame('migration_corrected_name', $result['name']);
+        $this->assertArrayHasKey('label', $result);
+    }
+
+    public function testUpdateNameViaMigrationPathPersistsInDatabase(): void
+    {
+        $container = $this->createFieldContainer([
+            'label'        => 'MigrationPath ' . $this->getUniqueString(),
+            'type'         => 'tab',
+            'itemtypes'    => [Computer::class],
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $new_name = 'migrated_' . $container->fields['name'];
+        $container->update(['id' => $container->getID(), 'name' => $new_name]);
+
+        $refreshed = new PluginFieldsContainer();
+        $refreshed->getFromDB($container->getID());
+
+        $this->assertSame($new_name, $refreshed->fields['name']);
     }
 }

--- a/tests/Units/ContainerTest.php
+++ b/tests/Units/ContainerTest.php
@@ -151,12 +151,16 @@ final class ContainerTest extends DbTestCase
             'is_recursive' => 1,
         ]);
 
-        $new_name = 'migrated_' . $container->fields['name'];
+        $original_name = $container->fields['name'];
+        $new_name = 'mig_' . substr($original_name, 0, 20);
+
         $container->update(['id' => $container->getID(), 'name' => $new_name]);
 
         $refreshed = new PluginFieldsContainer();
         $refreshed->getFromDB($container->getID());
-
         $this->assertSame($new_name, $refreshed->fields['name']);
+
+        // Restore original name so teardown can locate and drop the physical table
+        $container->update(['id' => $container->getID(), 'name' => $original_name]);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

During plugin installation when migrating containers from GenericObject to
CustomAsset, containers end up with a corrupted `name` field (e.g.
`sixonefourfourthreesixtwozeroeight`) and an empty `label`, causing a
subsequent MySQL error when the dynamic table name exceeds 64 characters.

### Root cause

`installBaseData` calls `update()` with only `id` and `itemtypes`  (no `label` key  to update) see L249

`prepareInputForUpdate()` called `prepareLabel()` unconditionally, which:

1. passed `''` to `getSystemNameFromLabel()`, which fell back to
   `random_int(0, mt_getrandmax())` for an empty name
2. passed that integer through `replaceIntByLetters()`, spelling each
   digit out (`6 1 4 4 3 6 2 0 0 8`  =>  `sixonefourfourthreesixtwozeroeight`)

### State before migration

mysql> SELECT id, name, label, itemtypes FROM glpi_plugin_fields_c
+----+---------+---------+--------------------------------+
| id | name    | label   | itemtypes                      |
+----+---------+---------+--------------------------------+
|  3 | contain | contain | ["PluginGenericobjectContain"] |
+----+---------+---------+--------------------------------+

### State after migration (buggy)

+----+------------------------------------+-------+-------------------------------------+
| id | name                               | label | itemtypes
+----+------------------------------------+-------+-------------------------------------+
|  3 | sixonefourfourthreesixtwozeroeight |       | ["Glpi\CustomA
+----+------------------------------------+-------+-------------------------------------+

This triggers:

RuntimeException: MySQL query error: Identifier name
'glpi_plugin_fields_glpicustomassetcontainassetsixonefourfourthree
is too long (1059)

