### PR TITLE
Fix(Migration): prevent container name corruption on partial update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+### Fixed
+
+- Remove redundant null coalescing on container label preparation.
 
 ## [1.24.2] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix item creation with null value for mandatory fields
 - Fix search crash when two containers share a dropdown field with the same name.
 - Fix handle native GLPI dropdown types when binding additional fields to form destination
-- Remove redundant null coalescing on container label preparation.
-
+- Fix container name/label corruption during GenericObject migration, which could break the migration with a MySQL identifier-length error.
 
 ## [1.24.2] - 2026-06-30
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -651,7 +651,7 @@ class PluginFieldsContainer extends CommonDBTM
     {
         // if label not empty, prepare name from label
         if (isset($input['label']) && !empty($input['label'])) {
-            $input['label'] = PluginFieldsToolbox::sanitizeLabel((string) ($input['label'] ?? ''));
+            $input['label'] = PluginFieldsToolbox::sanitizeLabel((string) $input['label']);
         }
 
         return $input;

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -241,6 +241,7 @@ class PluginFieldsContainer extends CommonDBTM
                     $update_data = [
                         'id'        => $container['id'],
                         'itemtypes' => $itemtypes,
+                        'label'     => $container['label'],
                     ];
                     if ($container_name !== $container['name']) {
                         $update_data['name'] = $container_name;
@@ -648,7 +649,11 @@ class PluginFieldsContainer extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
-        return PluginFieldsToolbox::prepareLabel($input);
+        // if label not empty, prepare name from label
+        if (isset($input['label']) && !empty($input['label'])) {
+            $input = PluginFieldsToolbox::prepareLabel($input);
+        }
+        return $input;
     }
 
     public function prepareInputForAdd($input)

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -650,10 +650,10 @@ class PluginFieldsContainer extends CommonDBTM
     public function prepareInputForUpdate($input)
     {
         // if label not empty, prepare name from label
-        // if label not empty, prepare name from label
         if (isset($input['label']) && !empty($input['label'])) {
             $input['label'] = PluginFieldsToolbox::sanitizeLabel((string) ($input['label'] ?? ''));
         }
+
         return $input;
     }
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -650,8 +650,9 @@ class PluginFieldsContainer extends CommonDBTM
     public function prepareInputForUpdate($input)
     {
         // if label not empty, prepare name from label
+        // if label not empty, prepare name from label
         if (isset($input['label']) && !empty($input['label'])) {
-            $input = PluginFieldsToolbox::prepareLabel($input);
+            $input['label'] = PluginFieldsToolbox::sanitizeLabel((string) ($input['label'] ?? ''));
         }
         return $input;
     }

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -649,7 +649,7 @@ class PluginFieldsContainer extends CommonDBTM
 
     public function prepareInputForUpdate($input)
     {
-        // if label not empty, prepare name from label
+        // sanitize label only; name is intentionally left untouched here (see migration callers)
         if (isset($input['label']) && !empty($input['label'])) {
             $input['label'] = PluginFieldsToolbox::sanitizeLabel((string) $input['label']);
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Replace https://github.com/pluginsGLPI/fields/pull/1221

Fixes : 43878, 45265

## Description

During plugin installation when migrating containers from GenericObject to
CustomAsset, containers end up with a corrupted `name` field (e.g.
`sixonefourfourthreesixtwozeroeight`) and an empty `label`, causing a
subsequent MySQL error when the dynamic table name exceeds 64 characters.

### Root cause

`installBaseData` calls `update()` with only `id` and `itemtypes`  (no `label` key  to update) see L249

`prepareInputForUpdate()` called `prepareLabel()` unconditionally, which:

1. passed `''` to `getSystemNameFromLabel()`, which fell back to
   `random_int(0, mt_getrandmax())` for an empty name
2. passed that integer through `replaceIntByLetters()`, spelling each
   digit out (`6 1 4 4 3 6 2 0 0 8`  =>  `sixonefourfourthreesixtwozeroeight`)

### State before migration

mysql> SELECT id, name, label, itemtypes FROM glpi_plugin_fields_cintainers;
+----+---------+---------+--------------------------------+
| id | name    | label   | itemtypes                      |
+----+---------+---------+--------------------------------+
|  3 | contain | contain | ["PluginGenericobjectContain"] |
+----+---------+---------+--------------------------------+

### State after migration (buggy)

+----+------------------------------------+-------+-------------------------------------+
| id | name                               | label | itemtypes
+----+------------------------------------+-------+-------------------------------------+
|  3 | sixonefourfourthreesixtwozeroeight |       | ["Glpi\CustomA
+----+------------------------------------+-------+-------------------------------------+

This triggers:

RuntimeException: MySQL query error: Identifier name
'glpi_plugin_fields_glpicustomassetcontainassetsixonefourfourthree
is too long (1059)

## Screenshots (if appropriate):
