### PR TITLE
fix(container.class): Prevent item creation with null value for mandatory fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix item creation with null value for mandatory fields
 - Fix search crash when two containers share a dropdown field with the same name.
 
 ## [1.24.2] - 2026-06-30

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1970,12 +1970,19 @@ HTML;
             return true;
         }
 
+        //call validateValues() with a minimal data array to check for missing mandatory fields
+        //in case populateData() fails
         if ($item->isNewItem() && $loc_c->fields['type'] === 'dom') {
+            $status_field_name = PluginFieldsStatusOverride::getStatusFieldName($item::getType());
             $data = ['plugin_fields_containers_id' => $c_id];
+            if (array_key_exists($status_field_name, $item->input) && $item->input[$status_field_name] !== '') {
+                $data[$status_field_name] = (int) $item->input[$status_field_name];
+            } elseif (array_key_exists($status_field_name, $item->fields) && $item->fields[$status_field_name] !== '') {
+                $data[$status_field_name] = (int) $item->fields[$status_field_name];
+            }
+
             if (self::validateValues($data, $item::getType(), isset($_REQUEST['massiveaction'])) === false) {
                 $item->input = [];
-
-                return false;
             }
         }
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1970,6 +1970,15 @@ HTML;
             return true;
         }
 
+        if ($item->isNewItem() && $loc_c->fields['type'] === 'dom') {
+            $data = ['plugin_fields_containers_id' => $c_id];
+            if (self::validateValues($data, $item::getType(), isset($_REQUEST['massiveaction'])) === false) {
+                $item->input = [];
+
+                return false;
+            }
+        }
+
         return false;
     }
 

--- a/tests/Units/ContainerItemUpdateTest.php
+++ b/tests/Units/ContainerItemUpdateTest.php
@@ -311,6 +311,124 @@ final class ContainerItemUpdateTest extends DbTestCase
         $this->assertSame('created via api', $plugin_row[$field_name]);
     }
 
+    public function testCreateIsBlockedWhenMandatoryDomFieldIsMissing(): void
+    {
+        $this->login();
+
+        $container = $this->createFieldContainer([
+            'label'        => 'Mandatory Create Container',
+            'type'         => 'dom',
+            'itemtypes'    => [Ticket::class],
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $field = $this->createField([
+            'label'                                     => 'Mandatory Field',
+            'type'                                      => 'text',
+            PluginFieldsContainer::getForeignKeyField() => $container->getID(),
+            'ranking'                                   => 1,
+            'is_active'                                 => 1,
+            'is_readonly'                               => 0,
+            'mandatory'                                 => 1,
+        ]);
+        $field_name = $field->fields['name'];
+
+        $this->simulateApiBoot();
+
+        // Creation with the mandatory field omitted must be rejected.
+        $ticket = new Ticket();
+        $ticket_id = $ticket->add([
+            'name'        => 'Ticket without mandatory field',
+            'content'     => 'Test creation',
+            'entities_id' => 0,
+        ]);
+        $this->assertFalse($ticket_id, 'Creation must be blocked when a mandatory dom field is missing.');
+        $this->hasSessionMessageThatContains(
+            __('Some mandatory fields are empty', 'fields'),
+            ERROR,
+        );
+
+        // Creation with the mandatory field filled must succeed.
+        $ticket = new Ticket();
+        $ticket_id = $ticket->add([
+            'name'        => 'Ticket with mandatory field',
+            'content'     => 'Test creation',
+            'entities_id' => 0,
+            $field_name   => 'filled value',
+        ]);
+        $this->assertGreaterThan(0, $ticket_id);
+
+        $plugin_row = $this->getPluginFieldValues(Ticket::class, $ticket_id, $container->getID());
+        $this->assertNotFalse($plugin_row);
+        $this->assertSame('filled value', $plugin_row[$field_name]);
+    }
+
+    public function testCreateIsNotBlockedWhenMandatoryTabOrDomtabFieldIsMissing(): void
+    {
+        $this->login();
+
+        // TAB container with a mandatory field.
+        $tab_container = $this->createFieldContainer([
+            'label'        => 'Mandatory Tab Container',
+            'type'         => 'tab',
+            'itemtypes'    => [Ticket::class],
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $this->createField([
+            'label'                                     => 'Mandatory Tab Field',
+            'type'                                      => 'text',
+            PluginFieldsContainer::getForeignKeyField() => $tab_container->getID(),
+            'ranking'                                   => 1,
+            'is_active'                                 => 1,
+            'is_readonly'                               => 0,
+            'mandatory'                                 => 1,
+        ]);
+
+        // DOMTAB container with a mandatory field, attached to a specific tab.
+        $domtab_container = $this->createFieldContainer([
+            'label'        => 'Mandatory Domtab Container',
+            'type'         => 'domtab',
+            'subtype'      => Ticket::class . '$1',
+            'itemtypes'    => [Ticket::class],
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $this->createField([
+            'label'                                     => 'Mandatory Domtab Field',
+            'type'                                      => 'text',
+            PluginFieldsContainer::getForeignKeyField() => $domtab_container->getID(),
+            'ranking'                                   => 1,
+            'is_active'                                 => 1,
+            'is_readonly'                               => 0,
+            'mandatory'                                 => 1,
+        ]);
+
+        // Creation with no plugin field must not block the creation.
+        $ticket = new Ticket();
+        $ticket_id = $ticket->add([
+            'name'        => 'Ticket with mandatory tab field missing',
+            'content'     => 'Test creation',
+            'entities_id' => 0,
+        ]);
+        $this->assertGreaterThan(0, $ticket_id, 'A mandatory tab field must not block creation.');
+
+        // Creation forcing the "domtab" container resolution via explicit c_id:
+        // it must not block the creation either.
+        $ticket = new Ticket();
+        $ticket_id = $ticket->add([
+            'name'        => 'Ticket with mandatory domtab field missing',
+            'content'     => 'Test creation',
+            'entities_id' => 0,
+            'c_id'        => $domtab_container->getID(),
+        ]);
+        $this->assertGreaterThan(0, $ticket_id, 'A mandatory domtab field must not block creation.');
+    }
+
     /**
      * Update a ticket with explicit c_id through an API-like context.
      */


### PR DESCRIPTION


## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45283
- Before this fix, in `preItem()`, the validation of required fields (`validateValues()`) was only called if `populateData()` did not return `false`. However, `populateData()` returns `false` when none of the block's fields are present in the input. Result: A creation that did not submit the fields (API/CLI, or a form without mapping) completely bypassed the check and created the element with a `NULL` value in a required field.
- Fix:  On creation only (`isNewItem()`), when `populateData()` returns `false` and the continer type is `dom`, `validateValues()` is still called on an empty dataset, which causes the missing required fields to fail validation and blocks creation.