### PR TITLE
fix handle native glpi dropdown types when binding additional field to form destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix item creation with null value for mandatory fields
 - Fix search crash when two containers share a dropdown field with the same name.
+- fix handle native GLPI dropdown types when binding additional fields to form destination
 
 ## [1.24.2] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix item creation with null value for mandatory fields
 - Fix search crash when two containers share a dropdown field with the same name.
-- fix handle native GLPI dropdown types when binding additional fields to form destination
+- Fix handle native GLPI dropdown types when binding additional fields to form destination
 
 ## [1.24.2] - 2026-06-30
 

--- a/inc/destinationfield.class.php
+++ b/inc/destinationfield.class.php
@@ -134,8 +134,8 @@ class PluginFieldsDestinationField extends AbstractConfigField
                 if ($field->fields['type'] == 'glpi_item') {
                     $input[sprintf('itemtype_%s', $field_name)] = $answer->getRawAnswer()['itemtype'];
                     $input[sprintf('items_id_%s', $field_name)] = $answer->getRawAnswer()['items_id'];
-                } elseif ($field->fields['type'] == 'dropdown') {
-                    $raw_id = (int) $answer->getRawAnswer()['items_id'];
+                } elseif (str_starts_with((string) $field->fields['type'], 'dropdown')) {
+                    $raw_id = (int) ($answer->getRawAnswer()['items_id'] ?? 0);
                     $input[$field_name] = ($raw_id > 0) ? $raw_id : null;
                 } else {
                     $input[$field_name] = $value ?? $answer->getRawAnswer();

--- a/inc/questiontype.class.php
+++ b/inc/questiontype.class.php
@@ -248,7 +248,7 @@ final class PluginFieldsQuestionType extends AbstractQuestionType implements For
 
             $names = [];
             foreach ($answer as $items_id) {
-                $item = $itemtype::getById($items_id);
+                $item = $itemtype::getById((int) $items_id);
                 if ($item) {
                     $names[] = $item->fields['name'];
                 }

--- a/tests/Units/FieldDestinationFieldTest.php
+++ b/tests/Units/FieldDestinationFieldTest.php
@@ -236,7 +236,12 @@ final class FieldDestinationFieldTest extends AbstractDestinationFieldTest
             form: $form,
             config: new SimpleValueConfig(1),
             answers: [
-                "Location Field" => $location->getID(),
+                // The end user template submits dropdowns as an array
+                // containing the selected itemtype and items_id.
+                "Location Field" => [
+                    'itemtype' => Location::class,
+                    'items_id' => $location->getID(),
+                ],
             ],
             expected_field_values: [
                 Ticket::class => [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45483
- Fixes the submission of a form containing an additional field of the native glpi dropdown type (e.g : Groups) linked to a destination. The raw response (itemtype/items_id array) was inserted into the database, causing an SQL error and an error when rendering the response.
We now extract the items_id for all dropdown types, and the id is cast to int before being read.


