### PR TITLE
Fix: check rights and escape output on field forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix missing right checks on some ajax config endpoints and escape default value and URL field output.
 - Fix item creation with null value for mandatory fields
 - Fix search crash when two containers share a dropdown field with the same name.
 - Fix handle native GLPI dropdown types when binding additional fields to form destination

--- a/ajax/container_display_condition.php
+++ b/ajax/container_display_condition.php
@@ -27,7 +27,7 @@
  * @link      https://github.com/pluginsGLPI/fields
  * -------------------------------------------------------------------------
  */
-Session::checkLoginUser();
+Session::checkRight('config', READ);
 
 if (isset($_GET['action'])) {
     if ($_GET['action'] === 'get_add_form') {

--- a/ajax/container_itemtypes_dropdown.php
+++ b/ajax/container_itemtypes_dropdown.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 Session::checkLoginUser();
 
 PluginFieldsContainer::showFormItemtype($_REQUEST);

--- a/ajax/container_subtype_dropdown.php
+++ b/ajax/container_subtype_dropdown.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 Session::checkLoginUser();
 
 PluginFieldsContainer::showFormSubtype($_REQUEST, true);

--- a/ajax/field_specific_fields.php
+++ b/ajax/field_specific_fields.php
@@ -33,7 +33,7 @@
 
 header('Content-Type: text/html; charset=UTF-8');
 Html::header_nocache();
-Session::checkLoginUser();
+Session::checkRight('config', READ);
 
 $id   = $_POST['id'];
 $type = $_POST['type'];

--- a/ajax/reorder.php
+++ b/ajax/reorder.php
@@ -30,7 +30,7 @@
 
 use Glpi\DBAL\QueryExpression;
 
-Session::checkLoginUser();
+Session::checkRight('config', UPDATE);
 
 if (
     !array_key_exists('container_id', $_POST)

--- a/ajax/status_override.php
+++ b/ajax/status_override.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-Session::checkLoginUser();
+Session::checkRight('config', READ);
 
 if (isset($_GET['action'])) {
     if ($_GET['action'] === 'get_status_dropdown') {

--- a/front/export_to_yaml.php
+++ b/front/export_to_yaml.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 include(__DIR__ . '/../hook.php');
 
 Session::checkRight('config', READ);

--- a/front/labeltranslation.form.php
+++ b/front/labeltranslation.form.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 Session::checkRight('config', UPDATE);
 
 $translation = new PluginFieldsLabelTranslation();

--- a/front/profile.form.php
+++ b/front/profile.form.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 Session::checkRight('config', UPDATE);
 
 if (isset($_POST['update'])) {

--- a/front/regenerate_files.php
+++ b/front/regenerate_files.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 include(__DIR__ . '/../hook.php');
 
 Session::checkRight('config', READ);

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -696,7 +696,7 @@ class PluginFieldsField extends CommonDBChild
                             echo Dropdown::getDropdownName($table, $this->fields['default_value']);
                         }
                     } else {
-                        echo $this->fields['default_value'];
+                        echo htmlspecialchars((string) $this->fields['default_value']);
                     }
 
                     echo '</td>';

--- a/rector.php
+++ b/rector.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/../../src/Plugin.php';
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;

--- a/templates/fields.html.twig
+++ b/templates/fields.html.twig
@@ -109,7 +109,7 @@
 
     {% elseif type == 'url' %}
             {% set ext_link %}
-            {% if value|length %}
+            {% if value|length and value matches '/^(https?|mailto):/i' %}
                 <a target="_blank" href="{{ value }}">
                     <i class="ti ti-external-link"></i>
                     {{ __('show', 'fields') }}

--- a/tests/Units/ContainerTest.php
+++ b/tests/Units/ContainerTest.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 namespace GlpiPlugin\Field\Tests\Units;
 
 use Computer;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,6 +28,8 @@
  * -------------------------------------------------------------------------
  */
 
+declare(strict_types=1);
+
 require __DIR__ . '/../../../tests/bootstrap.php';
 
 if (!Plugin::isPluginActive("fields")) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description
- fixes #N/A
Some ajax config endpoints only checked that the user was logged in, without verifying the config right, allowing any authenticated user to read or alter plugin field configuration.
The default value field listing and the URL field type also echoed stored values without escaping, allowing a stored value to be rendered as active content.
This change adds the missing right checks and escapes the affected outputs.

## Screenshots (if appropriate):
