### PR TITLE
Fix: trigger GenericObject dropdown fields migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix an error displayed on the UI when trying to create a bloc display condition based on "Type" or "Model" fields for custom assets
+- Fix GenericObject dropdown fields never being migrated to CustomAsset dropdown fields
 
 ## [1.24.3] - 2026-07-30
 

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -155,11 +155,9 @@ class PluginFieldsField extends CommonDBChild
 
         // Update old genericobject_itemtype dropdown fields to customasset_itemtype dropdown fields
         $has_genericobject_fields = $DB->tableExists('glpi_plugin_genericobject_types')
-            && $DB->request([
-                'COUNT' => 'id',
-                'FROM'  => self::getTable(),
-                'WHERE' => ['type' => ['LIKE', 'dropdown-PluginGenericobject%']],
-            ])->current()['COUNT(id)'] > 0;
+            && countElementsInTable(self::getTable(), [
+                'type' => ['LIKE', 'dropdown-PluginGenericobject%'],
+            ]) > 0;
         if ($has_genericobject_fields) {
             // Get all types from PluginGenericobject
             $migration_genericobject_itemtypes = PluginFieldsMigration::getGenericObjectTypes();

--- a/tests/Units/FieldGenericObjectMigrationTest.php
+++ b/tests/Units/FieldGenericObjectMigrationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Fields plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Fields.
+ *
+ * Fields is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Fields is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fields. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2013-2023 by Fields plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/fields
+ * -------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace GlpiPlugin\Field\Tests\Units;
+
+use DBmysql;
+use Glpi\Tests\DbTestCase;
+use Glpi\Tests\GLPITestCase;
+use GlpiPlugin\Field\Tests\FieldTestTrait;
+use PluginFieldsContainer;
+use PluginFieldsField;
+use PluginFieldsMigration;
+use Psr\Log\LogLevel;
+use RuntimeException;
+use Ticket;
+
+require_once __DIR__ . '/../FieldTestCase.php';
+
+final class FieldGenericObjectMigrationTest extends DbTestCase
+{
+    use FieldTestTrait;
+
+    public function setUp(): void
+    {
+        GLPITestCase::setUp();
+        $this->login();
+
+        /** @var DBmysql $DB */
+        global $DB;
+        $DB->doQuery(
+            'CREATE TABLE IF NOT EXISTS `glpi_plugin_genericobject_types` (
+                `id`       INT UNSIGNED NOT NULL AUTO_INCREMENT,
+                `itemtype` VARCHAR(255) DEFAULT NULL,
+                `name`     VARCHAR(255) DEFAULT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4',
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->tearDownFieldTest();
+
+        /** @var DBmysql $DB */
+        global $DB;
+        $DB->dropTable('glpi_plugin_genericobject_types');
+
+        GLPITestCase::tearDown();
+    }
+
+    public function testMigrationGuardTriggersWhenGenericobjectFieldsExist(): void
+    {
+        $container = $this->createFieldContainer([
+            'label'       => 'Genericobject Migration Container',
+            'type'        => 'tab',
+            'itemtypes'   => [Ticket::class],
+            'is_active'   => 1,
+            'entities_id' => 0,
+        ]);
+
+        $this->createField([
+            'label'                                      => 'Genericobject Field',
+            'type'                                        => 'dropdown-PluginGenericobjectFoo',
+            PluginFieldsContainer::getForeignKeyField() => $container->getID(),
+            'ranking'                                     => 1,
+            'is_active'                                   => 1,
+            'is_readonly'                                  => 0,
+        ]);
+
+        try {
+            PluginFieldsField::installBaseData(new PluginFieldsMigration('0'), '0');
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException $runtimeException) {
+            $this->assertStringContainsString('GenericObject plugin cannot be migrated', $runtimeException->getMessage());
+        }
+
+        $this->hasPhpLogRecordThatContains(
+            'plugin_version_genericobject method must be defined!',
+            LogLevel::WARNING,
+        );
+    }
+
+    public function testMigrationGuardDoesNotTriggerWithoutGenericobjectFields(): void
+    {
+        $container = $this->createFieldContainer([
+            'label'       => 'Regular Container',
+            'type'        => 'tab',
+            'itemtypes'   => [Ticket::class],
+            'is_active'   => 1,
+            'entities_id' => 0,
+        ]);
+
+        $this->createField([
+            'label'                                      => 'Plain Field',
+            'type'                                        => 'text',
+            PluginFieldsContainer::getForeignKeyField() => $container->getID(),
+            'ranking'                                     => 1,
+            'is_active'                                   => 1,
+            'is_readonly'                                  => 0,
+        ]);
+
+        $result = PluginFieldsField::installBaseData(new PluginFieldsMigration('0'), '0');
+
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43878
- The migration guard that detects legacy GenericObject dropdown fields read the wrong result key from the count query, so it always evaluated to false.
- As a result, GenericObject dropdown fields were never migrated to CustomAsset dropdown fields, and affected fields displayed the wrong label on item forms.

## Screenshots (if appropriate):
