### PR TITLE
Fix: check update rights on the item before saving additional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix additional fields being saved on an item the user is not allowed to update
+- Fix invalid characters being kept in the generated field name
+
 ## [1.24.4] - 2026-08-06
 
 ### Fixed

--- a/front/container.form.php
+++ b/front/container.form.php
@@ -55,6 +55,10 @@ if (isset($_POST['add'])) {
     $container->update($_POST);
     Html::back();
 } elseif (isset($_POST['update_fields_values'])) {
+    if (!PluginFieldsContainer::canUpdateTargetItem($_REQUEST['itemtype'] ?? '', (int) ($_REQUEST['items_id'] ?? 0))) {
+        throw new AccessDeniedHttpException();
+    }
+
     $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $_POST['plugin_fields_containers_id']);
     if ($right > READ) {
         $container->updateFieldsValues($_REQUEST, $_REQUEST['itemtype'], false);

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1356,6 +1356,19 @@ HTML;
     }
 
     /**
+     * Check that current user is allowed to update the item the fields values are attached to
+     *
+     * @param string  $itemtype Item type
+     * @param integer $items_id Item id
+     */
+    public static function canUpdateTargetItem(string $itemtype, int $items_id): bool
+    {
+        $item = (new DbUtils())->getItemForItemtype($itemtype);
+
+        return $item instanceof CommonDBTM && $item->can($items_id, UPDATE);
+    }
+
+    /**
      * Insert values submited by fields container
      *
      * @param array   $data          data posted

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -359,6 +359,10 @@ class PluginFieldsField extends CommonDBChild
 
     public function prepareInputForUpdate($input)
     {
+        if (array_key_exists('name', $input)) {
+            unset($input['name']); // system name is immutable after creation
+        }
+
         if (
             array_key_exists('default_value', $input)
             && $this->fields['multiple']
@@ -498,6 +502,12 @@ class PluginFieldsField extends CommonDBChild
         );
     }
 
+    // name is used as a column name, it must not contain anything else than SQL identifier safe chars
+    private function sanitizeSystemName(string $name): string
+    {
+        return (string) preg_replace('/[^a-z0-9_]/i', '', $name);
+    }
+
     /**
      * parse name for avoid non alphanumeric char in it and conflict with other fields
      * @param  array $input the field form input
@@ -508,8 +518,11 @@ class PluginFieldsField extends CommonDBChild
         $toolbox = new PluginFieldsToolbox();
 
         //contruct field name by processing label (remove non alphanumeric char)
-        if (empty($input['name'])) {
-            $input['name'] = $toolbox->getSystemNameFromLabel($input['label']) . 'field';
+        $input['name'] = $this->sanitizeSystemName($input['name'] ?? '');
+
+        // an empty name cannot be used as a column name
+        if ($input['name'] === '') {
+            $input['name'] = $toolbox->getSystemNameFromLabel($input['label'] ?? '') . 'field';
         }
 
         //for dropdown, if already exists, link to it
@@ -523,7 +536,7 @@ class PluginFieldsField extends CommonDBChild
         // for dropdowns like dropdown-User, dropdown-Computer, etc...
         $match = [];
         if (isset($input['type']) && preg_match('/^dropdown-(?<type>.+)$/', $input['type'], $match) === 1) {
-            $input['name'] = getForeignKeyFieldForItemType($match['type']) . '_' . $input['name'];
+            $input['name'] = $this->sanitizeSystemName(getForeignKeyFieldForItemType($match['type']) . '_' . $input['name']);
         }
 
         //check if field name not already exist and not in conflict with itemtype fields name

--- a/tests/Units/ContainerItemRightTest.php
+++ b/tests/Units/ContainerItemRightTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Fields plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Fields.
+ *
+ * Fields is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Fields is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fields. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2013-2023 by Fields plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/fields
+ * -------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace GlpiPlugin\Field\Tests\Units;
+
+use Computer;
+use Entity;
+use Glpi\Tests\DbTestCase;
+use PluginFieldsContainer;
+
+final class ContainerItemRightTest extends DbTestCase
+{
+    public function testCanUpdateTargetItemFollowsRightOnItem(): void
+    {
+        $this->login();
+        $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+        $this->setEntity($entity_id, true);
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'Computer ' . $this->getUniqueString(),
+            'entities_id' => $entity_id,
+        ]);
+
+        $this->assertTrue(PluginFieldsContainer::canUpdateTargetItem(Computer::class, $computer->getID()));
+
+        $this->login('post-only', 'postonly');
+        $this->setEntity($entity_id, true);
+
+        $this->assertFalse(PluginFieldsContainer::canUpdateTargetItem(Computer::class, $computer->getID()));
+    }
+
+    public function testCanUpdateTargetItemRejectsInvalidItemtype(): void
+    {
+        $this->login();
+
+        $this->assertFalse(PluginFieldsContainer::canUpdateTargetItem('', 1));
+    }
+}

--- a/tests/Units/FieldNameTest.php
+++ b/tests/Units/FieldNameTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Fields plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Fields.
+ *
+ * Fields is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Fields is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fields. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2013-2023 by Fields plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/fields
+ * -------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace GlpiPlugin\Field\Tests\Units;
+
+use Computer;
+use Glpi\Tests\DbTestCase;
+use Glpi\Tests\GLPITestCase;
+use GlpiPlugin\Field\Tests\FieldTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PluginFieldsField;
+
+require_once __DIR__ . '/../FieldTestCase.php';
+
+final class FieldNameTest extends DbTestCase
+{
+    use FieldTestTrait;
+
+    public function setUp(): void
+    {
+        GLPITestCase::setUp();
+        $this->login();
+    }
+
+    public function tearDown(): void
+    {
+        $this->tearDownFieldTest();
+        GLPITestCase::tearDown();
+    }
+
+    public static function provideFieldNames(): iterable
+    {
+        yield 'backticked ddl statement' => [
+            'name'     => 'aone`,DROP COLUMN `id',
+            'expected' => 'aoneDROPCOLUMNid',
+        ];
+
+        yield 'quotes and spaces' => [
+            'name'     => "my field'",
+            'expected' => 'myfield',
+        ];
+
+        yield 'already safe name' => [
+            'name'     => 'safe_name',
+            'expected' => 'safe_name',
+        ];
+
+        yield 'fully numeric name' => [
+            'name'     => '123',
+            'expected' => '123',
+        ];
+
+        yield 'name with digits' => [
+            'name'     => 'test123',
+            'expected' => 'test123',
+        ];
+
+        yield 'name emptied by sanitization' => [
+            'name'     => '!!!',
+            'expected' => 'fieldnamefield',
+        ];
+    }
+
+    public static function provideDropdownFieldNames(): iterable
+    {
+        yield 'standard itemtype' => [
+            'type'     => 'dropdown-' . Computer::class,
+            'name'     => "my field'",
+            'expected' => 'computers_id_myfield',
+        ];
+
+        yield 'itemtype with ddl chars' => [
+            'type'     => 'dropdown-Mon`itor',
+            'name'     => 'value',
+            'expected' => 'monitors_id_value',
+        ];
+    }
+
+    #[DataProvider('provideFieldNames')]
+    public function testPrepareNameKeepsOnlyIdentifierSafeChars(string $name, string $expected): void
+    {
+        $container = $this->createFieldContainer([
+            'label'        => 'Field name ' . $this->getUniqueString(),
+            'type'         => 'tab',
+            'itemtypes'    => [Computer::class],
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $prepared = (new PluginFieldsField())->prepareName([
+            'name'                        => $name,
+            'label'                       => 'Field name',
+            'type'                        => 'text',
+            'plugin_fields_containers_id' => $container->getID(),
+        ]);
+
+        $this->assertSame($expected, $prepared);
+    }
+
+    #[DataProvider('provideDropdownFieldNames')]
+    public function testPrepareNameSanitizesDropdownForeignKeyPrefix(string $type, string $name, string $expected): void
+    {
+        $container = $this->createFieldContainer([
+            'label'        => 'Field name ' . $this->getUniqueString(),
+            'type'         => 'tab',
+            'itemtypes'    => [Computer::class],
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $prepared = (new PluginFieldsField())->prepareName([
+            'name'                        => $name,
+            'label'                       => 'Field name',
+            'type'                        => $type,
+            'plugin_fields_containers_id' => $container->getID(),
+        ]);
+
+        $this->assertSame($expected, $prepared);
+    }
+
+    public function testUpdateCannotChangeSystemName(): void
+    {
+        $container = $this->createFieldContainer([
+            'label'        => 'Field name ' . $this->getUniqueString(),
+            'type'         => 'tab',
+            'itemtypes'    => [Computer::class],
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $field = $this->createField([
+            'name'                        => 'safe_name',
+            'label'                       => 'Field name',
+            'type'                        => 'text',
+            'ranking'                     => 1,
+            'plugin_fields_containers_id' => $container->getID(),
+            'is_active'                   => 1,
+        ]);
+
+        $this->assertTrue($field->update([
+            'id'                            => $field->getID(),
+            'name'                          => 'evil`,DROP COLUMN `id',
+            'label'                         => 'Renamed label',
+            'plugin_fields_containers_id'   => $container->getID(),
+        ]));
+
+        $this->assertTrue($field->getFromDB($field->getID()));
+        $this->assertSame('safe_name', $field->fields['name']);
+        $this->assertSame('Renamed label', $field->fields['label']);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- Saving the additional fields block only checked the profile right on the container, so a user could save values on an item located in another entity or on an item they are not allowed to update.
The update right on the target item is now required, which also enforces the entity restriction.
- The generated field name kept every character sent by the form when a name was provided, while it is used as a database column name.
The name is now always reduced to letters, digits and underscores.

## Screenshots (if appropriate):
