### PR TITLE
Some fix 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+- Fix additional fields being saved on an item the user is not allowed to update.
+- Fix invalid characters being kept in the generated field name.
+
 ## [1.21.29] - 2026-04-16
 
 - Fix application of the read-only option on RichText fields.

--- a/front/container.form.php
+++ b/front/container.form.php
@@ -54,6 +54,10 @@ if (isset($_POST['add'])) {
     $container->update($_POST);
     Html::back();
 } elseif (isset($_POST['update_fields_values'])) {
+    if (!PluginFieldsContainer::canUpdateTargetItem($_REQUEST['itemtype'] ?? '', (int) ($_REQUEST['items_id'] ?? 0))) {
+        Html::displayRightError("User is missing the " . UPDATE . " ('update') right on the target item");
+    }
+
     $right = PluginFieldsProfile::getRightOnContainer($_SESSION['glpiactiveprofile']['id'], $_POST['plugin_fields_containers_id']);
     if ($right > READ) {
         $container->updateFieldsValues($_REQUEST, $_REQUEST['itemtype'], false);

--- a/hook.php
+++ b/hook.php
@@ -160,6 +160,12 @@ function plugin_fields_uninstall()
         'itemtype' => ['LIKE' , 'PluginFields%'],
     ]);
 
+    // clean configuration values
+    $config = new Config();
+    $config->deleteByCriteria([
+        'context' => 'plugin:fields',
+    ]);
+
     return true;
 }
 

--- a/inc/container.class.php
+++ b/inc/container.class.php
@@ -1229,6 +1229,19 @@ HTML;
     }
 
     /**
+     * Check that current user is allowed to update the item the fields values are attached to
+     *
+     * @param string  $itemtype Item type
+     * @param integer $items_id Item id
+     */
+    public static function canUpdateTargetItem(string $itemtype, int $items_id): bool
+    {
+        $item = (new DbUtils())->getItemForItemtype($itemtype);
+
+        return $item instanceof CommonDBTM && $item->can($items_id, UPDATE);
+    }
+
+    /**
      * Insert values submited by fields container
      *
      * @param array   $data          data posted

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -321,6 +321,10 @@ class PluginFieldsField extends CommonDBChild
 
     public function prepareInputForUpdate($input)
     {
+        if (array_key_exists('name', $input)) {
+            unset($input['name']); // system name is immutable after creation
+        }
+
         if (
             array_key_exists('default_value', $input)
             && $this->fields['multiple']
@@ -440,6 +444,12 @@ class PluginFieldsField extends CommonDBChild
         );
     }
 
+    // name is used as a column name, it must not contain anything else than SQL identifier safe chars
+    private function sanitizeSystemName(string $name): string
+    {
+        return (string) preg_replace('/[^a-z0-9_]/i', '', $name);
+    }
+
     /**
      * parse name for avoid non alphanumeric char in it and conflict with other fields
      * @param  array $input the field form input
@@ -450,8 +460,11 @@ class PluginFieldsField extends CommonDBChild
         $toolbox = new PluginFieldsToolbox();
 
         //contruct field name by processing label (remove non alphanumeric char)
-        if (empty($input['name'])) {
-            $input['name'] = $toolbox->getSystemNameFromLabel($input['label']) . 'field';
+        $input['name'] = $this->sanitizeSystemName($input['name'] ?? '');
+
+        // an empty name cannot be used as a column name
+        if ($input['name'] === '') {
+            $input['name'] = $toolbox->getSystemNameFromLabel($input['label'] ?? '') . 'field';
         }
 
         //for dropdown, if already exists, link to it
@@ -465,7 +478,7 @@ class PluginFieldsField extends CommonDBChild
         // for dropdowns like dropdown-User, dropdown-Computer, etc...
         $match = [];
         if (isset($input['type']) && preg_match('/^dropdown-(?<type>.+)$/', $input['type'], $match) === 1) {
-            $input['name'] = getForeignKeyFieldForItemType($match['type']) . '_' . $input['name'];
+            $input['name'] = $this->sanitizeSystemName(getForeignKeyFieldForItemType($match['type']) . '_' . $input['name']);
         }
 
         //check if field name not already exist and not in conflict with itemtype fields name


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Backport for https://github.com/pluginsGLPI/fields/pull/1257

- Saving the additional fields block only checked the profile right on the container, so a user could save values on an item located in another entity or on an item they are not allowed to update.
The update right on the target item is now required, which also enforces the entity restriction.
- The generated field name kept every character sent by the form when a name was provided, while it is used as a database column name.
The name is now always reduced to letters, digits and underscores.

## Screenshots (if appropriate):
