### PR TITLE
1.24.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.24.5] - 2026-09-11
 
 ### Fixed
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -99,6 +99,16 @@ Il existe un [script de migration](https://github.com/pluginsGLPI/customfields/b
    </authors>
    <versions>
       <version>
+         <num>1.24.5</num>
+         <compatibility>~11.0.2</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.24.5/glpi-fields-1.24.5.tar.bz2</download_url>
+      </version>
+      <version>
+         <num>1.21.30</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.21.30/glpi-fields-1.21.30.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.24.4</num>
          <compatibility>~11.0.2</compatibility>
          <download_url>https://github.com/pluginsGLPI/fields/releases/download/1.24.4/glpi-fields-1.24.4.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 /** @var array $CFG_GLPI */
 global $CFG_GLPI;
 
-define('PLUGIN_FIELDS_VERSION', '1.24.4');
+define('PLUGIN_FIELDS_VERSION', '1.24.5');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_FIELDS_MIN_GLPI', '11.0.2');


### PR DESCRIPTION
## [1.24.5] - 2026-09-11

### Fixed

- Fix additional fields being saved on an item the user is not allowed to update
- Fix additional fields being displayed for an item the user is not allowed to read
- Fix invalid characters being kept in the generated field name
- Fix missing right checks on the target item when displaying or saving additional fields values